### PR TITLE
expose state and events

### DIFF
--- a/programs/multisig/src/lib.rs
+++ b/programs/multisig/src/lib.rs
@@ -1,11 +1,13 @@
 use anchor_lang::prelude::*;
 
+pub use events::*;
 use instructions::*;
+pub use state::*;
 
 mod errors;
-mod events;
+pub mod events;
 mod instructions;
-mod state;
+pub mod state;
 mod utils;
 
 declare_id!("7YYnaRgQeHYd2FKGKkwASM2ZNZHTo1GvcicsyKKFvcoh");


### PR DESCRIPTION
Expose the `state` and `events` modules for when program is used as a dependency