### PR TITLE
feat(permissions): make `mask` public

### DIFF
--- a/programs/multisig/src/state.rs
+++ b/programs/multisig/src/state.rs
@@ -122,7 +122,7 @@ pub enum Permission {
 /// Bitmask for permissions.
 #[derive(AnchorSerialize, AnchorDeserialize, Eq, PartialEq, Clone, Copy, Default, Debug)]
 pub struct Permissions {
-    mask: u8,
+    pub mask: u8,
 }
 
 impl Permissions {


### PR DESCRIPTION
Make the field `pub` so we could use it in account parsers