### PR TITLE
Fail when creating proposal for stale transaction

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -15,9 +15,9 @@ wallet = "~/.config/solana/id.json"
 [test.validator]
 url = "https://api.devnet.solana.com"
 
-# Token2022
-[[test.validator.clone]]
-address = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+## Token2022
+#[[test.validator.clone]]
+#address = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
 
 
 [scripts]

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -15,9 +15,9 @@ wallet = "~/.config/solana/id.json"
 [test.validator]
 url = "https://api.devnet.solana.com"
 
-## Token2022
-#[[test.validator.clone]]
-#address = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+# Token2022
+[[test.validator.clone]]
+address = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
 
 
 [scripts]

--- a/programs/multisig/src/instructions/proposal_create.rs
+++ b/programs/multisig/src/instructions/proposal_create.rs
@@ -53,6 +53,12 @@ impl ProposalCreate<'_> {
             MultisigError::InvalidTransactionIndex
         );
 
+        // We can't create a proposal for a stale transaction.
+        require!(
+            args.transaction_index > multisig.stale_transaction_index,
+            MultisigError::StaleProposal
+        );
+
         // Anyone can create a Proposal account. It's similar to ATA in this regard.
         // We don't require `Permission::Initiate` here because it's already implicitly checked
         // by the fact that a proposal can only be initialized if the corresponding transaction exists,

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,4 +1,5 @@
 // The order of imports is the order the test suite will run in.
 import "./suites/multisig-sdk";
 import "./suites/examples/batch-sol-transfer";
-import "./suites/examples/create-mint";
+// import "./suites/examples/create-mint";
+import "./suites/examples/immediate-execution";

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,5 @@
 // The order of imports is the order the test suite will run in.
 import "./suites/multisig-sdk";
 import "./suites/examples/batch-sol-transfer";
-// import "./suites/examples/create-mint";
+import "./suites/examples/create-mint";
 import "./suites/examples/immediate-execution";

--- a/tests/suites/examples/immediate-execution.ts
+++ b/tests/suites/examples/immediate-execution.ts
@@ -1,0 +1,93 @@
+import * as multisig from "@sqds/multisig";
+import { TransactionMessage, VersionedTransaction } from "@solana/web3.js";
+import assert from "assert";
+import {
+  createAutonomousMultisig,
+  createLocalhostConnection,
+  generateMultisigMembers,
+  TestMembers,
+} from "../../utils";
+
+const { Multisig } = multisig.accounts;
+
+/**
+ * If user can sign a transaction with enough member keys to reach the threshold,
+ * they can batch all multisig instructions required to create, approve and execute the multisig transaction
+ * into one Solana transaction, so the transaction is executed immediately.
+ */
+describe("Examples / Immediate Execution", () => {
+  const connection = createLocalhostConnection();
+
+  let members: TestMembers;
+  before(async () => {
+    members = await generateMultisigMembers(connection);
+  });
+
+  it("create, approve and execute, all in 1 Solana transaction", async () => {
+    const [multisigPda] = await createAutonomousMultisig({
+      connection,
+      members,
+      threshold: 1,
+      timeLock: 0,
+    });
+
+    const transactionIndex = 1n;
+
+    const createTransactionIx = multisig.instructions.configTransactionCreate({
+      multisigPda,
+      transactionIndex,
+      creator: members.almighty.publicKey,
+      // Change threshold to 2.
+      actions: [{ __kind: "ChangeThreshold", newThreshold: 2 }],
+    });
+    const createProposalIx = multisig.instructions.proposalCreate({
+      multisigPda,
+      transactionIndex,
+      rentPayer: members.almighty.publicKey,
+    });
+
+    const approveProposalIx = multisig.instructions.proposalApprove({
+      multisigPda,
+      transactionIndex,
+      member: members.almighty.publicKey,
+    });
+
+    const executeTransactionIx = multisig.instructions.configTransactionExecute(
+      {
+        multisigPda,
+        transactionIndex,
+        member: members.almighty.publicKey,
+        rentPayer: members.almighty.publicKey,
+      }
+    );
+
+    const message = new TransactionMessage({
+      payerKey: members.almighty.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [
+        createTransactionIx,
+        createProposalIx,
+        approveProposalIx,
+        executeTransactionIx,
+      ],
+    }).compileToV0Message();
+
+    const tx = new VersionedTransaction(message);
+
+    tx.sign([members.almighty]);
+
+    const signature = await connection.sendTransaction(tx, {
+      skipPreflight: true,
+    });
+    await connection.confirmTransaction(signature);
+
+    // Verify the multisig account.
+    const multisigAccount = await Multisig.fromAccountAddress(
+      connection,
+      multisigPda
+    );
+
+    // The threshold should be updated.
+    assert.strictEqual(multisigAccount.threshold, 2);
+  });
+});


### PR DESCRIPTION
Also refactor `multisig-sdk` tests so they don't work with shared global state and instead re-create the state in individual test suites.