### PR TITLE
feat(multisig_create): remove the 'signer' requirements from create_key

### DIFF
--- a/programs/multisig/src/instructions/multisig_create.rs
+++ b/programs/multisig/src/instructions/multisig_create.rs
@@ -29,9 +29,9 @@ pub struct MultisigCreate<'info> {
     )]
     pub multisig: Account<'info, Multisig>,
 
-    /// An ephemeral signer that is used as a seed for the Multisig PDA.
-    /// Must be a signer to prevent the Multisig account from re-initialization by someone else but the original creator.
-    pub create_key: Signer<'info>,
+    /// A random public key that is used as a seed for the Multisig PDA.
+    /// CHECK: This can be any random public key.
+    pub create_key: AccountInfo<'info>,
 
     /// The creator of the multisig.
     #[account(mut)]

--- a/sdk/multisig/idl/multisig.json
+++ b/sdk/multisig/idl/multisig.json
@@ -16,10 +16,9 @@
         {
           "name": "createKey",
           "isMut": false,
-          "isSigner": true,
+          "isSigner": false,
           "docs": [
-            "An ephemeral signer that is used as a seed for the Multisig PDA.",
-            "Must be a signer to prevent the Multisig account from re-initialization by someone else but the original creator."
+            "A random public key that is used as a seed for the Multisig PDA."
           ]
         },
         {

--- a/sdk/multisig/src/generated/instructions/multisigCreate.ts
+++ b/sdk/multisig/src/generated/instructions/multisigCreate.ts
@@ -40,7 +40,7 @@ export const multisigCreateStruct = new beet.FixableBeetArgsStruct<
  * Accounts required by the _multisigCreate_ instruction
  *
  * @property [_writable_] multisig
- * @property [**signer**] createKey
+ * @property [] createKey
  * @property [_writable_, **signer**] creator
  * @category Instructions
  * @category MultisigCreate
@@ -86,7 +86,7 @@ export function createMultisigCreateInstruction(
     {
       pubkey: accounts.createKey,
       isWritable: false,
-      isSigner: true,
+      isSigner: false,
     },
     {
       pubkey: accounts.creator,

--- a/sdk/multisig/src/rpc/multisigCreate.ts
+++ b/sdk/multisig/src/rpc/multisigCreate.ts
@@ -23,7 +23,7 @@ export async function multisigCreate({
   sendOptions,
 }: {
   connection: Connection;
-  createKey: Signer;
+  createKey: PublicKey;
   creator: Signer;
   multisigPda: PublicKey;
   configAuthority: PublicKey | null;
@@ -37,7 +37,7 @@ export async function multisigCreate({
 
   const tx = transactions.multisigCreate({
     blockhash,
-    createKey: createKey.publicKey,
+    createKey: createKey,
     creator: creator.publicKey,
     multisigPda,
     configAuthority,
@@ -47,7 +47,7 @@ export async function multisigCreate({
     memo,
   });
 
-  tx.sign([creator, createKey]);
+  tx.sign([creator]);
 
   try {
     return await connection.sendTransaction(tx, sendOptions);

--- a/tests/suites/multisig-sdk.ts
+++ b/tests/suites/multisig-sdk.ts
@@ -35,9 +35,9 @@ describe("Multisig SDK", () => {
     it("error: duplicate member", async () => {
       const creator = await generateFundedKeypair(connection);
 
-      const createKey = Keypair.generate();
+      const createKey = Keypair.generate().publicKey;
       const [multisigPda] = multisig.getMultisigPda({
-        createKey: createKey.publicKey,
+        createKey,
       });
 
       await assert.rejects(
@@ -66,49 +66,12 @@ describe("Multisig SDK", () => {
       );
     });
 
-    it("error: missing signature from `createKey`", async () => {
-      const creator = await generateFundedKeypair(connection);
-
-      const createKey = Keypair.generate();
-      const [multisigPda] = multisig.getMultisigPda({
-        createKey: createKey.publicKey,
-      });
-
-      const tx = multisig.transactions.multisigCreate({
-        blockhash: (await connection.getLatestBlockhash()).blockhash,
-        createKey: createKey.publicKey,
-        creator: creator.publicKey,
-        multisigPda,
-        configAuthority: null,
-        timeLock: 0,
-        threshold: 1,
-        members: [
-          {
-            key: members.almighty.publicKey,
-            permissions: Permissions.all(),
-          },
-          {
-            key: members.almighty.publicKey,
-            permissions: Permissions.all(),
-          },
-        ],
-      });
-
-      // Missing signature from `createKey`.
-      tx.sign([creator]);
-
-      await assert.rejects(
-        () => connection.sendTransaction(tx, { skipPreflight: true }),
-        /Transaction signature verification failure/
-      );
-    });
-
     it("error: empty members", async () => {
       const creator = await generateFundedKeypair(connection);
 
-      const createKey = Keypair.generate();
+      const createKey = Keypair.generate().publicKey;
       const [multisigPda] = multisig.getMultisigPda({
-        createKey: createKey.publicKey,
+        createKey,
       });
 
       await assert.rejects(
@@ -132,9 +95,9 @@ describe("Multisig SDK", () => {
       const creator = await generateFundedKeypair(connection);
       const member = Keypair.generate();
 
-      const createKey = Keypair.generate();
+      const createKey = Keypair.generate().publicKey;
       const [multisigPda] = multisig.getMultisigPda({
-        createKey: createKey.publicKey,
+        createKey,
       });
 
       await assert.rejects(
@@ -167,9 +130,9 @@ describe("Multisig SDK", () => {
     it("error: invalid threshold (< 1)", async () => {
       const creator = await generateFundedKeypair(connection);
 
-      const createKey = Keypair.generate();
+      const createKey = Keypair.generate().publicKey;
       const [multisigPda] = multisig.getMultisigPda({
-        createKey: createKey.publicKey,
+        createKey,
       });
 
       await assert.rejects(
@@ -195,9 +158,9 @@ describe("Multisig SDK", () => {
     it("error: invalid threshold (> members with permission to Vote)", async () => {
       const creator = await generateFundedKeypair(connection);
 
-      const createKey = Keypair.generate();
+      const createKey = Keypair.generate().publicKey;
       const [multisigPda] = multisig.getMultisigPda({
-        createKey: createKey.publicKey,
+        createKey: createKey,
       });
 
       await assert.rejects(
@@ -239,7 +202,7 @@ describe("Multisig SDK", () => {
     });
 
     it("create a new autonomous multisig", async () => {
-      const createKey = Keypair.generate();
+      const createKey = Keypair.generate().publicKey;
 
       const [multisigPda, multisigBump] = await createAutonomousMultisig({
         connection,
@@ -292,13 +255,13 @@ describe("Multisig SDK", () => {
       assert.strictEqual(multisigAccount.staleTransactionIndex.toString(), "0");
       assert.strictEqual(
         multisigAccount.createKey.toBase58(),
-        createKey.publicKey.toBase58()
+        createKey.toBase58()
       );
       assert.strictEqual(multisigAccount.bump, multisigBump);
     });
 
     it("create a new controlled multisig", async () => {
-      const createKey = Keypair.generate();
+      const createKey = Keypair.generate().publicKey;
       const configAuthority = await generateFundedKeypair(connection);
 
       const [multisigPda] = await createControlledMultisig({
@@ -344,7 +307,7 @@ describe("Multisig SDK", () => {
       multisigPda = (
         await createControlledMultisig({
           connection,
-          createKey: Keypair.generate(),
+          createKey: Keypair.generate().publicKey,
           configAuthority: configAuthority.publicKey,
           members,
           threshold: 2,
@@ -669,7 +632,7 @@ describe("Multisig SDK", () => {
     let multisigPda: PublicKey;
 
     before(async () => {
-      const msCreateKey = Keypair.generate();
+      const msCreateKey = Keypair.generate().publicKey;
 
       // Create new autonomous multisig.
       multisigPda = (
@@ -839,7 +802,7 @@ describe("Multisig SDK", () => {
     let multisigPda: PublicKey;
 
     before(async () => {
-      const msCreateKey = Keypair.generate();
+      const msCreateKey = Keypair.generate().publicKey;
 
       // Create new autonomous multisig.
       multisigPda = (
@@ -1026,7 +989,7 @@ describe("Multisig SDK", () => {
 
     before(async () => {
       const feePayer = await generateFundedKeypair(connection);
-      const msCreateKey = Keypair.generate();
+      const msCreateKey = Keypair.generate().publicKey;
 
       // Create new autonomous multisig.
       multisigPda = (
@@ -1197,7 +1160,7 @@ describe("Multisig SDK", () => {
 
     before(async () => {
       const feePayer = await generateFundedKeypair(connection);
-      const msCreateKey = Keypair.generate();
+      const msCreateKey = Keypair.generate().publicKey;
 
       // Create new autonomous multisig.
       multisigPda = (
@@ -1417,7 +1380,7 @@ describe("Multisig SDK", () => {
 
     before(async () => {
       const feePayer = await generateFundedKeypair(connection);
-      const msCreateKey = Keypair.generate();
+      const msCreateKey = Keypair.generate().publicKey;
 
       // Create new autonomous multisig.
       multisigPda = (
@@ -1830,9 +1793,9 @@ describe("Multisig SDK", () => {
     describe("getAvailableMemoSize", () => {
       it("provides estimates for available size to use for memo", async () => {
         const multisigCreator = await generateFundedKeypair(connection);
-        const createKey = Keypair.generate();
+        const createKey = Keypair.generate().publicKey;
         const [multisigPda] = multisig.getMultisigPda({
-          createKey: createKey.publicKey,
+          createKey,
         });
         const [configAuthority] = multisig.getVaultPda({
           multisigPda,
@@ -1843,7 +1806,7 @@ describe("Multisig SDK", () => {
           typeof multisig.transactions.multisigCreate
         >[0] = {
           blockhash: (await connection.getLatestBlockhash()).blockhash,
-          createKey: createKey.publicKey,
+          createKey,
           creator: multisigCreator.publicKey,
           multisigPda,
           configAuthority,
@@ -1873,7 +1836,7 @@ describe("Multisig SDK", () => {
         // The transaction with memo should have the maximum allowed size.
         assert.strictEqual(createMultisigTxWithMemo.serialize().length, 1232);
         // The transaction should work.
-        createMultisigTxWithMemo.sign([multisigCreator, createKey]);
+        createMultisigTxWithMemo.sign([multisigCreator]);
         const signature = await connection.sendTransaction(
           createMultisigTxWithMemo
         );

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -48,12 +48,12 @@ export async function generateMultisigMembers(
 
 export async function createAutonomousMultisig({
   connection,
-  createKey = Keypair.generate(),
+  createKey = Keypair.generate().publicKey,
   members,
   threshold,
   timeLock,
 }: {
-  createKey?: Keypair;
+  createKey?: PublicKey;
   members: TestMembers;
   threshold: number;
   timeLock: number;
@@ -62,7 +62,7 @@ export async function createAutonomousMultisig({
   const creator = await generateFundedKeypair(connection);
 
   const [multisigPda, multisigBump] = multisig.getMultisigPda({
-    createKey: createKey.publicKey,
+    createKey,
   });
 
   const signature = await multisig.rpc.multisigCreate({
@@ -87,7 +87,7 @@ export async function createAutonomousMultisig({
         permissions: Permissions.fromPermissions([Permission.Execute]),
       },
     ],
-    createKey: createKey,
+    createKey,
     sendOptions: { skipPreflight: true },
   });
 
@@ -98,13 +98,13 @@ export async function createAutonomousMultisig({
 
 export async function createControlledMultisig({
   connection,
-  createKey = Keypair.generate(),
+  createKey = Keypair.generate().publicKey,
   configAuthority,
   members,
   threshold,
   timeLock,
 }: {
-  createKey?: Keypair;
+  createKey?: PublicKey;
   configAuthority: PublicKey;
   members: TestMembers;
   threshold: number;
@@ -114,7 +114,7 @@ export async function createControlledMultisig({
   const creator = await generateFundedKeypair(connection);
 
   const [multisigPda, multisigBump] = multisig.getMultisigPda({
-    createKey: createKey.publicKey,
+    createKey,
   });
 
   const signature = await multisig.rpc.multisigCreate({
@@ -139,7 +139,7 @@ export async function createControlledMultisig({
         permissions: Permissions.fromPermissions([Permission.Execute]),
       },
     ],
-    createKey: createKey,
+    createKey,
     sendOptions: { skipPreflight: true },
   });
 


### PR DESCRIPTION
Remove the "signer" flag from `create_key`.

We made `create_key` a signer originally in order to make sure no one is able to re-create the squad at the same address in case we allow deleting squads. 
We never added that feature though, so `create_key`  being a signer doesn't really get us anything. At the same time it slightly worsens composability of the program, because an extra signer always makes things harder for the caller.

@RohanKapurDEV This shouldn't affect our indexer, but adding you as a reviewer to double-check it.
