### PR TITLE
feat(instructions): add rent_payer account

### DIFF
--- a/programs/multisig/src/instructions/batch_add_transaction.rs
+++ b/programs/multisig/src/instructions/batch_add_transaction.rs
@@ -21,10 +21,6 @@ pub struct BatchAddTransaction<'info> {
     )]
     pub multisig: Account<'info, Multisig>,
 
-    /// Member of the multisig.
-    #[account(mut)]
-    pub member: Signer<'info>,
-
     /// The proposal account associated with the batch.
     #[account(
         seeds = [
@@ -53,7 +49,7 @@ pub struct BatchAddTransaction<'info> {
     /// `VaultBatchTransaction` account to initialize and add to the `batch`.
     #[account(
         init,
-        payer = member,
+        payer = rent_payer,
         space = VaultBatchTransaction::size(args.ephemeral_signers, &args.transaction_message)?,
         seeds = [
             SEED_PREFIX,
@@ -66,6 +62,13 @@ pub struct BatchAddTransaction<'info> {
         bump
     )]
     pub transaction: Account<'info, VaultBatchTransaction>,
+
+    /// Member of the multisig.
+    pub member: Signer<'info>,
+
+    /// The payer for the batch transaction account rent.
+    #[account(mut)]
+    pub rent_payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/multisig/src/instructions/batch_create.rs
+++ b/programs/multisig/src/instructions/batch_create.rs
@@ -19,12 +19,9 @@ pub struct BatchCreate<'info> {
     )]
     pub multisig: Account<'info, Multisig>,
 
-    #[account(mut)]
-    pub creator: Signer<'info>,
-
     #[account(
         init,
-        payer = creator,
+        payer = rent_payer,
         space = 8 + Batch::INIT_SPACE,
         seeds = [
             SEED_PREFIX,
@@ -35,6 +32,13 @@ pub struct BatchCreate<'info> {
         bump
     )]
     pub batch: Account<'info, Batch>,
+
+    /// The member of the multisig that is creating the batch.
+    pub creator: Signer<'info>,
+
+    /// The payer for the batch account rent.
+    #[account(mut)]
+    pub rent_payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/multisig/src/instructions/config_transaction_create.rs
+++ b/programs/multisig/src/instructions/config_transaction_create.rs
@@ -21,7 +21,7 @@ pub struct ConfigTransactionCreate<'info> {
 
     #[account(
         init,
-        payer = creator,
+        payer = rent_payer,
         space = ConfigTransaction::size(&args.actions),
         seeds = [
             SEED_PREFIX,
@@ -33,8 +33,12 @@ pub struct ConfigTransactionCreate<'info> {
     )]
     pub transaction: Account<'info, ConfigTransaction>,
 
-    #[account(mut)]
+    /// The member of the multisig that is creating the transaction.
     pub creator: Signer<'info>,
+
+    /// The payer for the transaction account rent.
+    #[account(mut)]
+    pub rent_payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/multisig/src/instructions/proposal_create.rs
+++ b/programs/multisig/src/instructions/proposal_create.rs
@@ -22,7 +22,7 @@ pub struct ProposalCreate<'info> {
 
     #[account(
         init,
-        payer = creator,
+        payer = rent_payer,
         space = Proposal::size(multisig.members.len()),
         seeds = [
             SEED_PREFIX,
@@ -35,8 +35,12 @@ pub struct ProposalCreate<'info> {
     )]
     pub proposal: Account<'info, Proposal>,
 
-    #[account(mut)]
+    /// The member of the multisig that is creating the proposal.
     pub creator: Signer<'info>,
+
+    /// The payer for the proposal account rent.
+    #[account(mut)]
+    pub rent_payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/multisig/src/instructions/vault_transaction_create.rs
+++ b/programs/multisig/src/instructions/vault_transaction_create.rs
@@ -24,9 +24,9 @@ pub struct VaultTransactionCreate<'info> {
     )]
     pub multisig: Account<'info, Multisig>,
 
-    #[account(
+    #[account( 
         init,
-        payer = creator,
+        payer = rent_payer,
         space = VaultTransaction::size(args.ephemeral_signers, &args.transaction_message)?,
         seeds = [
             SEED_PREFIX,
@@ -38,8 +38,12 @@ pub struct VaultTransactionCreate<'info> {
     )]
     pub transaction: Account<'info, VaultTransaction>,
 
-    #[account(mut)]
+    /// The member of the multisig that is creating the transaction.
     pub creator: Signer<'info>,
+
+    /// The payer for the transaction account rent.
+    #[account(mut)]
+    pub rent_payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
 }

--- a/sdk/multisig/idl/multisig.json
+++ b/sdk/multisig/idl/multisig.json
@@ -347,8 +347,19 @@
         },
         {
           "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the transaction."
+          ]
+        },
+        {
+          "name": "rentPayer",
           "isMut": true,
-          "isSigner": true
+          "isSigner": true,
+          "docs": [
+            "The payer for the transaction account rent."
+          ]
         },
         {
           "name": "systemProgram",
@@ -445,8 +456,19 @@
         },
         {
           "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the transaction."
+          ]
+        },
+        {
+          "name": "rentPayer",
           "isMut": true,
-          "isSigner": true
+          "isSigner": true,
+          "docs": [
+            "The payer for the transaction account rent."
+          ]
         },
         {
           "name": "systemProgram",
@@ -511,14 +533,25 @@
           "isSigner": false
         },
         {
-          "name": "creator",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
           "name": "batch",
           "isMut": true,
           "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the batch."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The payer for the batch account rent."
+          ]
         },
         {
           "name": "systemProgram",
@@ -550,14 +583,6 @@
           ]
         },
         {
-          "name": "member",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Member of the multisig."
-          ]
-        },
-        {
           "name": "proposal",
           "isMut": false,
           "isSigner": false,
@@ -576,6 +601,22 @@
           "isSigner": false,
           "docs": [
             "`VaultBatchTransaction` account to initialize and add to the `batch`."
+          ]
+        },
+        {
+          "name": "member",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Member of the multisig."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The payer for the batch transaction account rent."
           ]
         },
         {
@@ -658,8 +699,19 @@
         },
         {
           "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the proposal."
+          ]
+        },
+        {
+          "name": "rentPayer",
           "isMut": true,
-          "isSigner": true
+          "isSigner": true,
+          "docs": [
+            "The payer for the proposal account rent."
+          ]
         },
         {
           "name": "systemProgram",

--- a/sdk/multisig/src/generated/instructions/batchAddTransaction.ts
+++ b/sdk/multisig/src/generated/instructions/batchAddTransaction.ts
@@ -40,20 +40,22 @@ export const batchAddTransactionStruct = new beet.FixableBeetArgsStruct<
  * Accounts required by the _batchAddTransaction_ instruction
  *
  * @property [] multisig
- * @property [_writable_, **signer**] member
  * @property [] proposal
  * @property [_writable_] batch
  * @property [_writable_] transaction
+ * @property [**signer**] member
+ * @property [_writable_, **signer**] rentPayer
  * @category Instructions
  * @category BatchAddTransaction
  * @category generated
  */
 export type BatchAddTransactionInstructionAccounts = {
   multisig: web3.PublicKey
-  member: web3.PublicKey
   proposal: web3.PublicKey
   batch: web3.PublicKey
   transaction: web3.PublicKey
+  member: web3.PublicKey
+  rentPayer: web3.PublicKey
   systemProgram?: web3.PublicKey
   anchorRemainingAccounts?: web3.AccountMeta[]
 }
@@ -88,11 +90,6 @@ export function createBatchAddTransactionInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.member,
-      isWritable: true,
-      isSigner: true,
-    },
-    {
       pubkey: accounts.proposal,
       isWritable: false,
       isSigner: false,
@@ -106,6 +103,16 @@ export function createBatchAddTransactionInstruction(
       pubkey: accounts.transaction,
       isWritable: true,
       isSigner: false,
+    },
+    {
+      pubkey: accounts.member,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.rentPayer,
+      isWritable: true,
+      isSigner: true,
     },
     {
       pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,

--- a/sdk/multisig/src/generated/instructions/batchCreate.ts
+++ b/sdk/multisig/src/generated/instructions/batchCreate.ts
@@ -37,16 +37,18 @@ export const batchCreateStruct = new beet.FixableBeetArgsStruct<
  * Accounts required by the _batchCreate_ instruction
  *
  * @property [_writable_] multisig
- * @property [_writable_, **signer**] creator
  * @property [_writable_] batch
+ * @property [**signer**] creator
+ * @property [_writable_, **signer**] rentPayer
  * @category Instructions
  * @category BatchCreate
  * @category generated
  */
 export type BatchCreateInstructionAccounts = {
   multisig: web3.PublicKey
-  creator: web3.PublicKey
   batch: web3.PublicKey
+  creator: web3.PublicKey
+  rentPayer: web3.PublicKey
   systemProgram?: web3.PublicKey
   anchorRemainingAccounts?: web3.AccountMeta[]
 }
@@ -81,14 +83,19 @@ export function createBatchCreateInstruction(
       isSigner: false,
     },
     {
-      pubkey: accounts.creator,
-      isWritable: true,
-      isSigner: true,
-    },
-    {
       pubkey: accounts.batch,
       isWritable: true,
       isSigner: false,
+    },
+    {
+      pubkey: accounts.creator,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.rentPayer,
+      isWritable: true,
+      isSigner: true,
     },
     {
       pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,

--- a/sdk/multisig/src/generated/instructions/configTransactionCreate.ts
+++ b/sdk/multisig/src/generated/instructions/configTransactionCreate.ts
@@ -41,7 +41,8 @@ export const configTransactionCreateStruct = new beet.FixableBeetArgsStruct<
  *
  * @property [_writable_] multisig
  * @property [_writable_] transaction
- * @property [_writable_, **signer**] creator
+ * @property [**signer**] creator
+ * @property [_writable_, **signer**] rentPayer
  * @category Instructions
  * @category ConfigTransactionCreate
  * @category generated
@@ -50,6 +51,7 @@ export type ConfigTransactionCreateInstructionAccounts = {
   multisig: web3.PublicKey
   transaction: web3.PublicKey
   creator: web3.PublicKey
+  rentPayer: web3.PublicKey
   systemProgram?: web3.PublicKey
   anchorRemainingAccounts?: web3.AccountMeta[]
 }
@@ -90,6 +92,11 @@ export function createConfigTransactionCreateInstruction(
     },
     {
       pubkey: accounts.creator,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.rentPayer,
       isWritable: true,
       isSigner: true,
     },

--- a/sdk/multisig/src/generated/instructions/proposalCreate.ts
+++ b/sdk/multisig/src/generated/instructions/proposalCreate.ts
@@ -41,7 +41,8 @@ export const proposalCreateStruct = new beet.BeetArgsStruct<
  *
  * @property [] multisig
  * @property [_writable_] proposal
- * @property [_writable_, **signer**] creator
+ * @property [**signer**] creator
+ * @property [_writable_, **signer**] rentPayer
  * @category Instructions
  * @category ProposalCreate
  * @category generated
@@ -50,6 +51,7 @@ export type ProposalCreateInstructionAccounts = {
   multisig: web3.PublicKey
   proposal: web3.PublicKey
   creator: web3.PublicKey
+  rentPayer: web3.PublicKey
   systemProgram?: web3.PublicKey
   anchorRemainingAccounts?: web3.AccountMeta[]
 }
@@ -90,6 +92,11 @@ export function createProposalCreateInstruction(
     },
     {
       pubkey: accounts.creator,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.rentPayer,
       isWritable: true,
       isSigner: true,
     },

--- a/sdk/multisig/src/generated/instructions/vaultTransactionCreate.ts
+++ b/sdk/multisig/src/generated/instructions/vaultTransactionCreate.ts
@@ -41,7 +41,8 @@ export const vaultTransactionCreateStruct = new beet.FixableBeetArgsStruct<
  *
  * @property [_writable_] multisig
  * @property [_writable_] transaction
- * @property [_writable_, **signer**] creator
+ * @property [**signer**] creator
+ * @property [_writable_, **signer**] rentPayer
  * @category Instructions
  * @category VaultTransactionCreate
  * @category generated
@@ -50,6 +51,7 @@ export type VaultTransactionCreateInstructionAccounts = {
   multisig: web3.PublicKey
   transaction: web3.PublicKey
   creator: web3.PublicKey
+  rentPayer: web3.PublicKey
   systemProgram?: web3.PublicKey
   anchorRemainingAccounts?: web3.AccountMeta[]
 }
@@ -90,6 +92,11 @@ export function createVaultTransactionCreateInstruction(
     },
     {
       pubkey: accounts.creator,
+      isWritable: false,
+      isSigner: true,
+    },
+    {
+      pubkey: accounts.rentPayer,
       isWritable: true,
       isSigner: true,
     },

--- a/sdk/multisig/src/instructions/batchAddTransaction.ts
+++ b/sdk/multisig/src/instructions/batchAddTransaction.ts
@@ -16,6 +16,7 @@ export function batchAddTransaction({
   vaultIndex,
   multisigPda,
   member,
+  rentPayer,
   batchIndex,
   transactionIndex,
   ephemeralSigners,
@@ -24,7 +25,10 @@ export function batchAddTransaction({
 }: {
   vaultIndex: number;
   multisigPda: PublicKey;
+  /** Member of the multisig that is adding the transaction. */
   member: PublicKey;
+  /** Payer for the transaction account rent. If not provided, `member` is used. */
+  rentPayer?: PublicKey;
   batchIndex: bigint;
   transactionIndex: number;
   /** Number of additional signing PDAs required by the transaction. */
@@ -64,6 +68,7 @@ export function batchAddTransaction({
       multisig: multisigPda,
       member,
       proposal: proposalPda,
+      rentPayer: rentPayer ?? member,
       batch: batchPda,
       transaction: batchTransactionPda,
     },

--- a/sdk/multisig/src/instructions/batchCreate.ts
+++ b/sdk/multisig/src/instructions/batchCreate.ts
@@ -5,12 +5,16 @@ import { getTransactionPda } from "../pda";
 export function batchCreate({
   multisigPda,
   creator,
+  rentPayer,
   batchIndex,
   vaultIndex,
   memo,
 }: {
   multisigPda: PublicKey;
+  /** Member of the multisig that is creating the batch. */
   creator: PublicKey;
+  /** Payer for the batch account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   batchIndex: bigint;
   vaultIndex: number;
   memo?: string;
@@ -24,6 +28,7 @@ export function batchCreate({
     {
       multisig: multisigPda,
       creator,
+      rentPayer: rentPayer ?? creator,
       batch: batchPda,
     },
     { args: { vaultIndex, memo: memo ?? null } }

--- a/sdk/multisig/src/instructions/configTransactionCreate.ts
+++ b/sdk/multisig/src/instructions/configTransactionCreate.ts
@@ -7,13 +7,17 @@ import { getTransactionPda } from "../pda";
 
 export function configTransactionCreate({
   multisigPda,
-  creator,
   transactionIndex,
+  creator,
+  rentPayer,
   actions,
   memo,
 }: {
   multisigPda: PublicKey;
+  /** Member of the multisig that is creating the transaction. */
   creator: PublicKey;
+  /** Payer for the transaction account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   transactionIndex: bigint;
   actions: ConfigAction[];
   memo?: string;
@@ -24,7 +28,12 @@ export function configTransactionCreate({
   });
 
   return createConfigTransactionCreateInstruction(
-    { creator, multisig: multisigPda, transaction: transactionPda },
+    {
+      multisig: multisigPda,
+      transaction: transactionPda,
+      creator,
+      rentPayer: rentPayer ?? creator,
+    },
     { args: { actions, memo: memo ?? null } }
   );
 }

--- a/sdk/multisig/src/instructions/proposalCreate.ts
+++ b/sdk/multisig/src/instructions/proposalCreate.ts
@@ -5,11 +5,15 @@ import { getProposalPda } from "../pda";
 export function proposalCreate({
   multisigPda,
   creator,
+  rentPayer,
   transactionIndex,
   isDraft = false,
 }: {
   multisigPda: PublicKey;
+  /** Member of the multisig that is creating the proposal. */
   creator: PublicKey;
+  /** Payer for the proposal account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   transactionIndex: bigint;
   isDraft?: boolean;
 }) {
@@ -23,7 +27,12 @@ export function proposalCreate({
   }
 
   return createProposalCreateInstruction(
-    { creator, multisig: multisigPda, proposal: proposalPda },
+    {
+      creator,
+      rentPayer: rentPayer ?? creator,
+      multisig: multisigPda,
+      proposal: proposalPda,
+    },
     { args: { transactionIndex: Number(transactionIndex), draft: isDraft } }
   );
 }

--- a/sdk/multisig/src/instructions/vaultTransactionCreate.ts
+++ b/sdk/multisig/src/instructions/vaultTransactionCreate.ts
@@ -11,6 +11,7 @@ export function vaultTransactionCreate({
   multisigPda,
   transactionIndex,
   creator,
+  rentPayer,
   vaultIndex,
   ephemeralSigners,
   transactionMessage,
@@ -20,6 +21,7 @@ export function vaultTransactionCreate({
   multisigPda: PublicKey;
   transactionIndex: bigint;
   creator: PublicKey;
+  rentPayer?: PublicKey;
   vaultIndex: number;
   /** Number of additional signing PDAs required by the transaction. */
   ephemeralSigners: number;
@@ -51,6 +53,7 @@ export function vaultTransactionCreate({
       multisig: multisigPda,
       transaction: transactionPda,
       creator,
+      rentPayer: rentPayer ?? creator,
     },
     {
       args: {

--- a/sdk/multisig/src/rpc/batchCreate.ts
+++ b/sdk/multisig/src/rpc/batchCreate.ts
@@ -15,6 +15,7 @@ export async function batchCreate({
   multisigPda,
   batchIndex,
   creator,
+  rentPayer,
   vaultIndex,
   memo,
   signers,
@@ -24,7 +25,10 @@ export async function batchCreate({
   feePayer: Signer;
   multisigPda: PublicKey;
   batchIndex: bigint;
+  /** Member of the multisig that is creating the batch. */
   creator: Signer;
+  /** Payer for the batch account rent. If not provided, `creator` is used. */
+  rentPayer?: Signer;
   vaultIndex: number;
   memo?: string;
   signers?: Signer[];
@@ -38,11 +42,19 @@ export async function batchCreate({
     multisigPda,
     batchIndex,
     creator: creator.publicKey,
+    rentPayer: rentPayer?.publicKey ?? creator.publicKey,
     vaultIndex,
     memo,
   });
 
-  tx.sign([feePayer, creator, ...(signers ?? [])]);
+  const allSigners = [feePayer, creator];
+  if (signers) {
+    allSigners.push(...signers);
+  }
+  if (rentPayer) {
+    allSigners.push(rentPayer);
+  }
+  tx.sign(allSigners);
 
   try {
     return await connection.sendTransaction(tx, sendOptions);

--- a/sdk/multisig/src/rpc/configTransactionCreate.ts
+++ b/sdk/multisig/src/rpc/configTransactionCreate.ts
@@ -16,6 +16,7 @@ export async function configTransactionCreate({
   multisigPda,
   transactionIndex,
   creator,
+  rentPayer,
   actions,
   memo,
   signers,
@@ -25,7 +26,10 @@ export async function configTransactionCreate({
   feePayer: Signer;
   multisigPda: PublicKey;
   transactionIndex: bigint;
+  /** Member of the multisig that is creating the transaction. */
   creator: PublicKey;
+  /** Payer for the transaction account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   actions: ConfigAction[];
   memo?: string;
   signers?: Signer[];
@@ -39,6 +43,7 @@ export async function configTransactionCreate({
     multisigPda,
     transactionIndex,
     creator,
+    rentPayer,
     actions,
     memo,
   });

--- a/sdk/multisig/src/rpc/proposalCreate.ts
+++ b/sdk/multisig/src/rpc/proposalCreate.ts
@@ -12,6 +12,7 @@ export async function proposalCreate({
   connection,
   feePayer,
   creator,
+  rentPayer,
   multisigPda,
   transactionIndex,
   isDraft,
@@ -19,7 +20,10 @@ export async function proposalCreate({
 }: {
   connection: Connection;
   feePayer: Signer;
+  /** Member of the multisig that is creating the proposal. */
   creator: Signer;
+  /** Payer for the proposal account rent. If not provided, `creator` is used. */
+  rentPayer?: Signer;
   multisigPda: PublicKey;
   transactionIndex: bigint;
   isDraft?: boolean;
@@ -36,7 +40,11 @@ export async function proposalCreate({
     isDraft,
   });
 
-  tx.sign([feePayer, creator]);
+  const allSigners = [feePayer, creator];
+  if (rentPayer) {
+    allSigners.push(rentPayer);
+  }
+  tx.sign(allSigners);
 
   try {
     return await connection.sendTransaction(tx, sendOptions);

--- a/sdk/multisig/src/rpc/vaultTransactionCreate.ts
+++ b/sdk/multisig/src/rpc/vaultTransactionCreate.ts
@@ -17,6 +17,7 @@ export async function vaultTransactionCreate({
   multisigPda,
   transactionIndex,
   creator,
+  rentPayer,
   vaultIndex,
   ephemeralSigners,
   transactionMessage,
@@ -29,11 +30,14 @@ export async function vaultTransactionCreate({
   feePayer: Signer;
   multisigPda: PublicKey;
   transactionIndex: bigint;
+  /** Member of the multisig that is creating the transaction. */
   creator: PublicKey;
+  /** Payer for the transaction account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   vaultIndex: number;
   /** Number of ephemeral signing PDAs required by the transaction. */
   ephemeralSigners: number;
-/** Transaction message to wrap into a multisig transaction. */
+  /** Transaction message to wrap into a multisig transaction. */
   transactionMessage: TransactionMessage;
   /** `AddressLookupTableAccount`s referenced in `transaction_message`. */
   addressLookupTableAccounts?: AddressLookupTableAccount[];
@@ -49,6 +53,7 @@ export async function vaultTransactionCreate({
     multisigPda,
     transactionIndex,
     creator,
+    rentPayer,
     vaultIndex,
     ephemeralSigners,
     transactionMessage,

--- a/sdk/multisig/src/transactions/batchAddTransaction.ts
+++ b/sdk/multisig/src/transactions/batchAddTransaction.ts
@@ -16,6 +16,7 @@ export async function batchAddTransaction({
   feePayer,
   multisigPda,
   member,
+  rentPayer,
   vaultIndex,
   batchIndex,
   transactionIndex,
@@ -26,7 +27,10 @@ export async function batchAddTransaction({
   connection: Connection;
   feePayer: PublicKey;
   multisigPda: PublicKey;
+  /** Member of the multisig that is creating the transaction. */
   member: PublicKey;
+  /** Payer for the transaction account rent. If not provided, `member` is used. */
+  rentPayer?: PublicKey;
   vaultIndex: number;
   batchIndex: bigint;
   transactionIndex: number;
@@ -47,6 +51,7 @@ export async function batchAddTransaction({
         vaultIndex,
         multisigPda,
         member,
+        rentPayer,
         batchIndex,
         transactionIndex,
         ephemeralSigners,

--- a/sdk/multisig/src/transactions/batchCreate.ts
+++ b/sdk/multisig/src/transactions/batchCreate.ts
@@ -15,6 +15,7 @@ export function batchCreate({
   multisigPda,
   batchIndex,
   creator,
+  rentPayer,
   vaultIndex,
   memo,
 }: {
@@ -22,7 +23,10 @@ export function batchCreate({
   feePayer: PublicKey;
   multisigPda: PublicKey;
   batchIndex: bigint;
+  /** Member of the multisig that is creating the batch. */
   creator: PublicKey;
+  /** Payer for the batch account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   vaultIndex: number;
   memo?: string;
 }): VersionedTransaction {
@@ -33,6 +37,7 @@ export function batchCreate({
       instructions.batchCreate({
         multisigPda,
         creator,
+        rentPayer: rentPayer ?? creator,
         batchIndex,
         vaultIndex,
         memo,

--- a/sdk/multisig/src/transactions/configTransactionCreate.ts
+++ b/sdk/multisig/src/transactions/configTransactionCreate.ts
@@ -14,6 +14,7 @@ export function configTransactionCreate({
   blockhash,
   feePayer,
   creator,
+  rentPayer,
   multisigPda,
   transactionIndex,
   actions,
@@ -21,7 +22,10 @@ export function configTransactionCreate({
 }: {
   blockhash: string;
   feePayer: PublicKey;
+  /** Member of the multisig that is creating the transaction. */
   creator: PublicKey;
+  /** Payer for the transaction account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   multisigPda: PublicKey;
   transactionIndex: bigint;
   actions: ConfigAction[];
@@ -33,6 +37,7 @@ export function configTransactionCreate({
     instructions: [
       instructions.configTransactionCreate({
         creator,
+        rentPayer,
         multisigPda,
         transactionIndex,
         actions,

--- a/sdk/multisig/src/transactions/proposalCreate.ts
+++ b/sdk/multisig/src/transactions/proposalCreate.ts
@@ -16,13 +16,17 @@ export function proposalCreate({
   multisigPda,
   transactionIndex,
   creator,
+  rentPayer,
   isDraft,
 }: {
   blockhash: string;
   feePayer: PublicKey;
   multisigPda: PublicKey;
   transactionIndex: bigint;
+  /** Member of the multisig that is creating the proposal. */
   creator: PublicKey;
+  /** Payer for the proposal account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   isDraft?: boolean;
 }): VersionedTransaction {
   const message = new TransactionMessage({
@@ -32,6 +36,7 @@ export function proposalCreate({
       instructions.proposalCreate({
         multisigPda,
         creator,
+        rentPayer,
         transactionIndex,
         isDraft,
       }),

--- a/sdk/multisig/src/transactions/vaultTransactionCreate.ts
+++ b/sdk/multisig/src/transactions/vaultTransactionCreate.ts
@@ -8,7 +8,7 @@ import * as instructions from "../instructions/index";
 
 /**
  * Returns unsigned `VersionedTransaction` that needs to be
- * signed by `creator` and `feePayer` before sending it.
+ * signed by `creator`, `rentPayer` and `feePayer` before sending it.
  */
 export function vaultTransactionCreate({
   blockhash,
@@ -16,6 +16,7 @@ export function vaultTransactionCreate({
   multisigPda,
   transactionIndex,
   creator,
+  rentPayer,
   vaultIndex,
   ephemeralSigners,
   transactionMessage,
@@ -26,7 +27,10 @@ export function vaultTransactionCreate({
   feePayer: PublicKey;
   multisigPda: PublicKey;
   transactionIndex: bigint;
+  /** Member of the multisig that is creating the transaction. */
   creator: PublicKey;
+  /** Payer for the transaction account rent. If not provided, `creator` is used. */
+  rentPayer?: PublicKey;
   vaultIndex: number;
   /** Number of additional signing PDAs required by the transaction. */
   ephemeralSigners: number;
@@ -44,6 +48,7 @@ export function vaultTransactionCreate({
         multisigPda,
         transactionIndex,
         creator,
+        rentPayer,
         vaultIndex,
         ephemeralSigners,
         transactionMessage,


### PR DESCRIPTION
This allows decoupling of the transaction creator from the account that pays fees for the account rent. 
Facilitates use-cases like transaction fees relayer and PDA creators