### PR TITLE
Add ability for the config authority to create a config transaction

### DIFF
--- a/programs/squads_multisig_program/src/errors.rs
+++ b/programs/squads_multisig_program/src/errors.rs
@@ -82,4 +82,6 @@ pub enum MultisigError {
     BatchNotEmpty,
     #[msg("Invalid SpendingLimit amount")]
     SpendingLimitInvalidAmount,
+    #[msg("Config authority is not a signer")]
+    ConfigAuthorityIsNotSigner,
 }

--- a/programs/squads_multisig_program/src/instructions/config_transaction_create.rs
+++ b/programs/squads_multisig_program/src/instructions/config_transaction_create.rs
@@ -46,11 +46,13 @@ pub struct ConfigTransactionCreate<'info> {
 impl ConfigTransactionCreate<'_> {
     fn validate(&self, args: &ConfigTransactionCreateArgs) -> Result<()> {
         // multisig
-        require_keys_eq!(
-            self.multisig.config_authority,
-            Pubkey::default(),
-            MultisigError::NotSupportedForControlled
-        );
+        if self.multisig.config_authority != Pubkey::default() {
+            require_keys_eq!(
+                self.creator.key(),
+                self.multisig.config_authority,
+                MultisigError::ConfigAuthorityIsNotSigner
+            );
+        }
 
         // creator
         require!(


### PR DESCRIPTION
Why ? 
The current set up makes it impossible for a multisig with a config authority to create config action. This introduces difficulties for programs with custom logic building on top of Squads v4.

Solution
Letting the config authority initialize config actions(transactions) makes it possible to create regular multisigs governed by a programmatic config authority, which opens up a lot of possibilities for developers building on Squads.

Security
Only allowing config actions to be executed while there is a config authority would cause a problem though, which is that the multisig could overthrow the config authority by consensus, which we don't want. That is why the config authority needs to be the creator of the config transaction.