### PR TITLE
SDK: Expose "multisigChangeThreshold" in instructions and transactions

### DIFF
--- a/sdk/multisig/src/instructions/index.ts
+++ b/sdk/multisig/src/instructions/index.ts
@@ -9,6 +9,7 @@ export * from "./multisigCreate.js";
 export * from "./multisigCreateV2.js";
 export * from "./multisigAddMember.js";
 export * from "./multisigAddSpendingLimit.js";
+export * from "./multisigChangeThreshold.js";
 export * from "./multisigRemoveSpendingLimit.js";
 export * from "./multisigSetConfigAuthority.js";
 export * from "./multisigSetRentCollector.js";

--- a/sdk/multisig/src/instructions/multisigChangeThreshold.ts
+++ b/sdk/multisig/src/instructions/multisigChangeThreshold.ts
@@ -1,0 +1,37 @@
+import { PublicKey } from "@solana/web3.js";
+import {
+  createMultisigChangeThresholdInstruction,
+  PROGRAM_ID,
+} from "../generated";
+
+export function multisigChangeThreshold({
+  multisigPda,
+  configAuthority,
+  rentPayer,
+  newThreshold,
+  memo,
+  programId = PROGRAM_ID,
+}: {
+  multisigPda: PublicKey;
+  spendingLimit: PublicKey;
+  configAuthority: PublicKey;
+  rentPayer: PublicKey;
+  newThreshold: number;
+  memo?: string;
+  programId?: PublicKey;
+}) {
+  return createMultisigChangeThresholdInstruction(
+    {
+      multisig: multisigPda,
+      configAuthority,
+      rentPayer,
+    },
+    {
+      args: {
+        newThreshold,
+        memo: memo ?? null,
+      },
+    },
+    programId
+  );
+}

--- a/sdk/multisig/src/instructions/multisigChangeThreshold.ts
+++ b/sdk/multisig/src/instructions/multisigChangeThreshold.ts
@@ -13,7 +13,6 @@ export function multisigChangeThreshold({
   programId = PROGRAM_ID,
 }: {
   multisigPda: PublicKey;
-  spendingLimit: PublicKey;
   configAuthority: PublicKey;
   rentPayer: PublicKey;
   newThreshold: number;

--- a/sdk/multisig/src/transactions/index.ts
+++ b/sdk/multisig/src/transactions/index.ts
@@ -8,6 +8,7 @@ export * from "./configTransactionExecute.js";
 export * from "./multisigAddMember.js";
 export * from "./multisigAddSpendingLimit.js";
 export * from "./multisigRemoveSpendingLimit.js";
+export * from "./multisigChangeThreshold.js";
 export * from "./multisigCreate.js";
 export * from "./multisigCreateV2.js";
 export * from "./multisigSetConfigAuthority.js";

--- a/sdk/multisig/src/transactions/multisigChangeThreshold.ts
+++ b/sdk/multisig/src/transactions/multisigChangeThreshold.ts
@@ -1,0 +1,49 @@
+import { 
+    PublicKey, 
+    TransactionMessage, 
+    VersionedTransaction 
+} from "@solana/web3.js";
+import {
+  PROGRAM_ID,
+} from "../generated";
+import { instructions } from "..";
+
+/**
+ * Returns unsigned `VersionedTransaction` that needs to be
+ * signed by `configAuthority` and `rentPayer` before sending it.
+ */
+export function multisigChangeThreshold({
+  blockhash,
+  multisigPda,
+  configAuthority,
+  rentPayer,
+  newThreshold,
+  memo,
+  programId = PROGRAM_ID,
+}: {
+  blockhash: string;
+  multisigPda: PublicKey;
+  spendingLimit: PublicKey;
+  configAuthority: PublicKey;
+  rentPayer: PublicKey;
+  newThreshold: number;
+  memo?: string;
+  programId?: PublicKey;
+}) {
+  const message = new TransactionMessage({
+    payerKey: rentPayer,
+    recentBlockhash: blockhash,
+    instructions: [
+        instructions.multisigChangeThreshold({
+            multisigPda,
+            configAuthority,
+            rentPayer,
+            newThreshold,
+            memo,
+            programId
+        })
+    ]
+  }).compileToV0Message();
+
+  return new VersionedTransaction(message);
+}


### PR DESCRIPTION
A few questions & confusions have came up lately regarding the "multisigChangeThreshold" being missing in the expected places, so I added and exposed it in both the "instructions" and "transactions" section