### PR TITLE
Additional duplicate check for multisig_add_member

### DIFF
--- a/programs/squads_multisig_program/src/instructions/multisig_config.rs
+++ b/programs/squads_multisig_program/src/instructions/multisig_config.rs
@@ -88,6 +88,9 @@ impl MultisigConfig<'_> {
 
         let multisig = &mut ctx.accounts.multisig;
 
+        // Make sure that the new member is not already in the multisig.
+        require!(multisig.is_member(new_member.key).is_none(), MultisigError::DuplicateMember);
+
         multisig.add_member(new_member);
 
         // Make sure the multisig account can fit the newly set rent_collector.


### PR DESCRIPTION
While the invariant functionality in the multisig struct offers comprehensive coverage of state management, we're adding an additional check in the multisig_add_member functionality to explicitly check for duplicates. This helps insure that the member key must be removed before re-added (in the case of changing permissions for example), as the invariant check is not able to distinguish which key should be removed upon upon the invariant check.