### PR TITLE
feat(spending_limits): allow spending limits for non-members

### DIFF
--- a/programs/squads_multisig_program/src/instructions/config_transaction_execute.rs
+++ b/programs/squads_multisig_program/src/instructions/config_transaction_execute.rs
@@ -143,14 +143,6 @@ impl<'info> ConfigTransactionExecute<'info> {
                     members,
                     destinations,
                 } => {
-                    // SpendingLimit members must all be members of the multisig.
-                    for sl_member in members.iter() {
-                        require!(
-                            multisig.is_member(*sl_member).is_some(),
-                            MultisigError::NotAMember
-                        );
-                    }
-
                     let (spending_limit_key, spending_limit_bump) = Pubkey::find_program_address(
                         &[
                             SEED_PREFIX,

--- a/programs/squads_multisig_program/src/instructions/multisig_add_spending_limit.rs
+++ b/programs/squads_multisig_program/src/instructions/multisig_add_spending_limit.rs
@@ -18,9 +18,8 @@ pub struct MultisigAddSpendingLimitArgs {
     /// The reset period of the spending limit.
     /// When it passes, the remaining amount is reset, unless it's `Period::OneTime`.
     pub period: Period,
-    /// Members of the multisig that can use the spending limit.
-    /// In case a member is removed from the multisig, the spending limit will remain existent
-    /// (until explicitly deleted), but the removed member will not be able to use it anymore.
+    /// Members of the Spending Limit that can use it.
+    /// Don't have to be members of the multisig.
     pub members: Vec<Pubkey>,
     /// The destination addresses the spending limit is allowed to sent funds to.
     /// If empty, funds can be sent to any address.
@@ -72,14 +71,6 @@ impl MultisigAddSpendingLimit<'_> {
         );
 
         // `spending_limit` is partially checked via its seeds.
-
-        // SpendingLimit members must all be members of the multisig.
-        for sl_member in self.spending_limit.members.iter() {
-            require!(
-                self.multisig.is_member(*sl_member).is_some(),
-                MultisigError::NotAMember
-            );
-        }
 
         Ok(())
     }

--- a/programs/squads_multisig_program/src/instructions/spending_limit_use.rs
+++ b/programs/squads_multisig_program/src/instructions/spending_limit_use.rs
@@ -98,11 +98,6 @@ impl SpendingLimitUse<'_> {
 
         // member
         require!(
-            multisig.is_member(member.key()).is_some(),
-            MultisigError::NotAMember
-        );
-        // We don't check member's permissions here but we check if the spending_limit is for the member.
-        require!(
             spending_limit.members.contains(&member.key()),
             MultisigError::Unauthorized
         );

--- a/sdk/multisig/idl/squads_multisig_program.json
+++ b/sdk/multisig/idl/squads_multisig_program.json
@@ -2055,9 +2055,8 @@
           {
             "name": "members",
             "docs": [
-              "Members of the multisig that can use the spending limit.",
-              "In case a member is removed from the multisig, the spending limit will remain existent",
-              "(until explicitly deleted), but the removed member will not be able to use it anymore."
+              "Members of the Spending Limit that can use it.",
+              "Don't have to be members of the multisig."
             ],
             "type": {
               "vec": "publicKey"

--- a/tests/suites/multisig-sdk.ts
+++ b/tests/suites/multisig-sdk.ts
@@ -843,7 +843,9 @@ describe("Multisig SDK", () => {
       );
     });
 
-    it("create a new Spending Limit for the controlled multisig", async () => {
+    it("create a new Spending Limit for the controlled multisig with member of the ms and non-member", async () => {
+      const nonMember = await generateFundedKeypair(connection);
+
       const signature = await multisig.rpc.multisigAddSpendingLimit({
         connection,
         feePayer: feePayer,
@@ -856,7 +858,7 @@ describe("Multisig SDK", () => {
         period: multisig.generated.Period.Day,
         mint: Keypair.generate().publicKey,
         destinations: [Keypair.generate().publicKey],
-        members: [members.almighty.publicKey],
+        members: [members.almighty.publicKey, nonMember.publicKey],
         vaultIndex: 1,
         signers: [feePayer, members.almighty],
         sendOptions: { skipPreflight: true },


### PR DESCRIPTION
After dog-fooding Spending Limits both in Squads and Fuse and having a deep discussion with the protocol team, we suggest to drop the requirement for the Spending Limits to only be usable by the members of the multisig. 

This allows for perfectly valid workflows that are pretty clanky right now, for example creating an SL for the fee relayer (currently this requires adding the relayer as a member to the multisig with no permissions). 

The potential risks are dangling SLs that are created for random keys and now forgotten, but in our opinion it's a case for proper multisig housekeeping - making sure your SLs are up to date and deleted when not needed anymore 