### PR TITLE
Execute optimizations

### DIFF
--- a/programs/squads_multisig_program/src/instructions/batch_execute_transaction.rs
+++ b/programs/squads_multisig_program/src/instructions/batch_execute_transaction.rs
@@ -150,10 +150,7 @@ impl BatchExecuteTransaction<'_> {
 
         // Execute the transaction message instructions one-by-one.
         executable_message.execute_message(
-            &vault_seeds
-                .iter()
-                .map(|seed| seed.to_vec())
-                .collect::<Vec<Vec<u8>>>(),
+            vault_seeds,
             &ephemeral_signer_seeds,
             protected_accounts,
         )?;

--- a/programs/squads_multisig_program/src/instructions/vault_transaction_execute.rs
+++ b/programs/squads_multisig_program/src/instructions/vault_transaction_execute.rs
@@ -130,10 +130,7 @@ impl VaultTransactionExecute<'_> {
 
         // Execute the transaction message instructions one-by-one.
         executable_message.execute_message(
-            &vault_seeds
-                .iter()
-                .map(|seed| seed.to_vec())
-                .collect::<Vec<Vec<u8>>>(),
+            vault_seeds,
             &ephemeral_signer_seeds,
             protected_accounts,
         )?;

--- a/programs/squads_multisig_program/src/utils/executable_transaction_message.rs
+++ b/programs/squads_multisig_program/src/utils/executable_transaction_message.rs
@@ -179,7 +179,7 @@ impl<'a, 'info> ExecutableTransactionMessage<'a, 'info> {
     /// * `protected_accounts` - Accounts that must not be passed as writable to the CPI calls to prevent potential reentrancy attacks.
     pub fn execute_message(
         &self,
-        vault_seeds: &[Vec<u8>],
+        vault_seeds: &[&[u8]],
         ephemeral_signer_seeds: &[Vec<Vec<u8>>],
         protected_accounts: &[Pubkey],
     ) -> Result<()> {
@@ -191,9 +191,6 @@ impl<'a, 'info> ExecutableTransactionMessage<'a, 'info> {
                     MultisigError::ProtectedAccount
                 );
             }
-
-            // Convert vault_seeds to Vec<&[u8]>.
-            let vault_seeds = vault_seeds.iter().map(Vec::as_slice).collect::<Vec<_>>();
 
             // First round of type conversion; from Vec<Vec<Vec<u8>>> to Vec<Vec<&[u8]>>.
             let ephemeral_signer_seeds = &ephemeral_signer_seeds


### PR DESCRIPTION
* We convert seeds to a vec, only to be reduced/collected as a slice again. This would simply pass the slice originally.
* Ephemeral/signer seeds don't change per loop iteration, moved the logic outside of the loop.