### PR TITLE
SDK: remove rimraf

### DIFF
--- a/sdk/multisig/package.json
+++ b/sdk/multisig/package.json
@@ -40,7 +40,6 @@
     "@metaplex-foundation/solita": "0.20.0",
     "@types/invariant": "2.2.35",
     "@types/node": "18.11.17",
-    "rimraf": "^6.0.1",
     "tsup": "^8.0.2",
     "typedoc": "^0.25.7",
     "typescript": "*"


### PR DESCRIPTION
Quick fix before the new version is shipped. `rimraf` is currently unused, and enforces a Node v20 as a minimum version

related to issue #116 