### PR TITLE
fix: comments from certora preliminary findings

### DIFF
--- a/programs/squads_multisig_program/src/instructions/transaction_buffer_close.rs
+++ b/programs/squads_multisig_program/src/instructions/transaction_buffer_close.rs
@@ -47,7 +47,7 @@ impl TransactionBufferClose<'_> {
         Ok(())
     }
 
-    /// Create a new vault transaction.
+    /// Close a transaction buffer account.
     #[access_control(ctx.accounts.validate())]
     pub fn transaction_buffer_close(ctx: Context<Self>) -> Result<()> {
         Ok(())

--- a/programs/squads_multisig_program/src/state/spending_limit.rs
+++ b/programs/squads_multisig_program/src/state/spending_limit.rs
@@ -66,7 +66,7 @@ impl SpendingLimit {
     }
 
     pub fn invariant(&self) -> Result<()> {
-        // Amount must be positive.
+        // Amount must be a non-zero value.
         require_neq!(self.amount, 0, MultisigError::SpendingLimitInvalidAmount);
 
         require!(!self.members.is_empty(), MultisigError::EmptyMembers);


### PR DESCRIPTION
Based on Certora's preliminary findings, this fixes comments in the following files:

- `transaction_buffer_close.rs`
- `spending_limit.rs`