### PR TITLE
Certora Audit Findings: Fix transaction_buffer_close seed constraints

### DIFF
--- a/programs/squads_multisig_program/src/instructions/transaction_buffer_close.rs
+++ b/programs/squads_multisig_program/src/instructions/transaction_buffer_close.rs
@@ -18,11 +18,13 @@ pub struct TransactionBufferClose<'info> {
         close = creator,
         // Only the creator can close the buffer
         constraint = transaction_buffer.creator == creator.key() @ MultisigError::Unauthorized,
+        // Account can be closed anytime by the creator, regardless of the
+        // current multisig transaction index
         seeds = [
             SEED_PREFIX,
             multisig.key().as_ref(),
             SEED_TRANSACTION_BUFFER,
-            &multisig.transaction_index.checked_add(1).unwrap().to_le_bytes(),
+            &transaction_buffer.transaction_index.to_le_bytes(),
         ],
         bump
     )]

--- a/programs/squads_multisig_program/src/instructions/transaction_buffer_extend.rs
+++ b/programs/squads_multisig_program/src/instructions/transaction_buffer_extend.rs
@@ -23,6 +23,8 @@ pub struct TransactionBufferExtend<'info> {
         mut,
         // Only the creator can extend the buffer
         constraint = transaction_buffer.creator == creator.key() @ MultisigError::Unauthorized,
+        // Extending the buffer only work if it still represents the next
+        // transaction index in the multisig
         seeds = [
             SEED_PREFIX,
             multisig.key().as_ref(),


### PR DESCRIPTION
Fixes the seed constraints of the `transaction_buffer_close` instruction to allow the creator to close the account at any time.