### PR TITLE
General Fixes

### DIFF
--- a/programs/squads_multisig_program/src/instructions/transaction_buffer_close.rs
+++ b/programs/squads_multisig_program/src/instructions/transaction_buffer_close.rs
@@ -24,7 +24,7 @@ pub struct TransactionBufferClose<'info> {
             SEED_PREFIX,
             multisig.key().as_ref(),
             SEED_TRANSACTION_BUFFER,
-            &transaction_buffer.transaction_index.to_le_bytes(),
+            &transaction_buffer.buffer_index.to_le_bytes()
         ],
         bump
     )]

--- a/programs/squads_multisig_program/src/instructions/transaction_buffer_create.rs
+++ b/programs/squads_multisig_program/src/instructions/transaction_buffer_create.rs
@@ -6,6 +6,8 @@ use crate::state::*;
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct TransactionBufferCreateArgs {
+    /// Index of the buffer account to seed the account derivation
+    pub buffer_index: u8,
     /// Index of the vault this transaction belongs to.
     pub vault_index: u8,
     /// Hash of the final assembled transaction message.
@@ -34,7 +36,7 @@ pub struct TransactionBufferCreate<'info> {
             SEED_PREFIX,
             multisig.key().as_ref(),
             SEED_TRANSACTION_BUFFER,
-            &multisig.transaction_index.checked_add(1).unwrap().to_le_bytes(),
+            &args.buffer_index.to_le_bytes(),
         ],
         bump
     )]
@@ -88,14 +90,14 @@ impl TransactionBufferCreate<'_> {
         let multisig = &ctx.accounts.multisig;
         let creator = &mut ctx.accounts.creator;
 
-        // Get the transaction index.
-        let transaction_index = multisig.transaction_index.checked_add(1).unwrap();
+        // Get the buffer index.
+        let buffer_index = args.buffer_index;
 
         // Initialize the transaction fields.
         transaction_buffer.multisig = multisig.key();
         transaction_buffer.creator = creator.key();
         transaction_buffer.vault_index = args.vault_index;
-        transaction_buffer.transaction_index = transaction_index;
+        transaction_buffer.buffer_index = buffer_index;
         transaction_buffer.final_buffer_hash = args.final_buffer_hash;
         transaction_buffer.final_buffer_size = args.final_buffer_size;
         transaction_buffer.buffer = args.buffer;

--- a/programs/squads_multisig_program/src/instructions/transaction_buffer_extend.rs
+++ b/programs/squads_multisig_program/src/instructions/transaction_buffer_extend.rs
@@ -23,13 +23,11 @@ pub struct TransactionBufferExtend<'info> {
         mut,
         // Only the creator can extend the buffer
         constraint = transaction_buffer.creator == creator.key() @ MultisigError::Unauthorized,
-        // Extending the buffer only work if it still represents the next
-        // transaction index in the multisig
         seeds = [
             SEED_PREFIX,
             multisig.key().as_ref(),
             SEED_TRANSACTION_BUFFER,
-            &multisig.transaction_index.checked_add(1).unwrap().to_le_bytes(),
+            &transaction_buffer.buffer_index.to_le_bytes()
         ],
         bump
     )]

--- a/programs/squads_multisig_program/src/instructions/vault_transaction_create_from_buffer.rs
+++ b/programs/squads_multisig_program/src/instructions/vault_transaction_create_from_buffer.rs
@@ -15,11 +15,7 @@ pub struct VaultTransactionCreateFromBuffer<'info> {
             SEED_PREFIX,
             vault_transaction_create.multisig.key().as_ref(),
             SEED_TRANSACTION_BUFFER,
-            &vault_transaction_create.multisig
-            .transaction_index
-            .checked_add(1)
-            .unwrap()
-            .to_le_bytes(),
+            &transaction_buffer.buffer_index.to_le_bytes(),
         ],
         bump
     )]

--- a/programs/squads_multisig_program/src/state/transaction_buffer.rs
+++ b/programs/squads_multisig_program/src/state/transaction_buffer.rs
@@ -12,10 +12,10 @@ pub struct TransactionBuffer {
     pub multisig: Pubkey,
     /// Member of the Multisig who created the TransactionBuffer.
     pub creator: Pubkey,
+    /// Index to seed address derivation
+    pub buffer_index: u8,
     /// Vault index of the transaction this buffer belongs to.
     pub vault_index: u8,
-    /// Index of the transaction this buffer belongs to.
-    pub transaction_index: u64,
     /// Hash of the final assembled transaction message.
     pub final_buffer_hash: [u8; 32],
     /// The size of the final assembled transaction message.
@@ -34,8 +34,8 @@ impl TransactionBuffer {
             8 +   // anchor account discriminator
             32 +  // multisig
             32 +  // creator
+            8 + //  buffer_index
             8 +   // vault_index
-            8 +   // transaction_index
             32 +  // transaction_message_hash
             2 +  // final_buffer_size
             4 + // vec length bytes

--- a/sdk/multisig/idl/squads_multisig_program.json
+++ b/sdk/multisig/idl/squads_multisig_program.json
@@ -2113,18 +2113,18 @@
             "type": "publicKey"
           },
           {
+            "name": "bufferIndex",
+            "docs": [
+              "Index to seed address derivation"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "vaultIndex",
             "docs": [
               "Vault index of the transaction this buffer belongs to."
             ],
             "type": "u8"
-          },
-          {
-            "name": "transactionIndex",
-            "docs": [
-              "Index of the transaction this buffer belongs to."
-            ],
-            "type": "u64"
           },
           {
             "name": "finalBufferHash",
@@ -2771,6 +2771,13 @@
       "type": {
         "kind": "struct",
         "fields": [
+          {
+            "name": "bufferIndex",
+            "docs": [
+              "Index of the buffer account to seed the account derivation"
+            ],
+            "type": "u8"
+          },
           {
             "name": "vaultIndex",
             "docs": [

--- a/sdk/multisig/src/generated/accounts/TransactionBuffer.ts
+++ b/sdk/multisig/src/generated/accounts/TransactionBuffer.ts
@@ -6,8 +6,8 @@
  */
 
 import * as web3 from '@solana/web3.js'
-import * as beet from '@metaplex-foundation/beet'
 import * as beetSolana from '@metaplex-foundation/beet-solana'
+import * as beet from '@metaplex-foundation/beet'
 
 /**
  * Arguments used to create {@link TransactionBuffer}
@@ -17,8 +17,8 @@ import * as beetSolana from '@metaplex-foundation/beet-solana'
 export type TransactionBufferArgs = {
   multisig: web3.PublicKey
   creator: web3.PublicKey
+  bufferIndex: number
   vaultIndex: number
-  transactionIndex: beet.bignum
   finalBufferHash: number[] /* size: 32 */
   finalBufferSize: number
   buffer: Uint8Array
@@ -38,8 +38,8 @@ export class TransactionBuffer implements TransactionBufferArgs {
   private constructor(
     readonly multisig: web3.PublicKey,
     readonly creator: web3.PublicKey,
+    readonly bufferIndex: number,
     readonly vaultIndex: number,
-    readonly transactionIndex: beet.bignum,
     readonly finalBufferHash: number[] /* size: 32 */,
     readonly finalBufferSize: number,
     readonly buffer: Uint8Array
@@ -52,8 +52,8 @@ export class TransactionBuffer implements TransactionBufferArgs {
     return new TransactionBuffer(
       args.multisig,
       args.creator,
+      args.bufferIndex,
       args.vaultIndex,
-      args.transactionIndex,
       args.finalBufferHash,
       args.finalBufferSize,
       args.buffer
@@ -167,18 +167,8 @@ export class TransactionBuffer implements TransactionBufferArgs {
     return {
       multisig: this.multisig.toBase58(),
       creator: this.creator.toBase58(),
+      bufferIndex: this.bufferIndex,
       vaultIndex: this.vaultIndex,
-      transactionIndex: (() => {
-        const x = <{ toNumber: () => number }>this.transactionIndex
-        if (typeof x.toNumber === 'function') {
-          try {
-            return x.toNumber()
-          } catch (_) {
-            return x
-          }
-        }
-        return x
-      })(),
       finalBufferHash: this.finalBufferHash,
       finalBufferSize: this.finalBufferSize,
       buffer: this.buffer,
@@ -200,8 +190,8 @@ export const transactionBufferBeet = new beet.FixableBeetStruct<
     ['accountDiscriminator', beet.uniformFixedSizeArray(beet.u8, 8)],
     ['multisig', beetSolana.publicKey],
     ['creator', beetSolana.publicKey],
+    ['bufferIndex', beet.u8],
     ['vaultIndex', beet.u8],
-    ['transactionIndex', beet.u64],
     ['finalBufferHash', beet.uniformFixedSizeArray(beet.u8, 32)],
     ['finalBufferSize', beet.u16],
     ['buffer', beet.bytes],

--- a/sdk/multisig/src/generated/types/TransactionBufferCreateArgs.ts
+++ b/sdk/multisig/src/generated/types/TransactionBufferCreateArgs.ts
@@ -7,6 +7,7 @@
 
 import * as beet from '@metaplex-foundation/beet'
 export type TransactionBufferCreateArgs = {
+  bufferIndex: number
   vaultIndex: number
   finalBufferHash: number[] /* size: 32 */
   finalBufferSize: number
@@ -20,6 +21,7 @@ export type TransactionBufferCreateArgs = {
 export const transactionBufferCreateArgsBeet =
   new beet.FixableBeetArgsStruct<TransactionBufferCreateArgs>(
     [
+      ['bufferIndex', beet.u8],
       ['vaultIndex', beet.u8],
       ['finalBufferHash', beet.uniformFixedSizeArray(beet.u8, 32)],
       ['finalBufferSize', beet.u16],

--- a/tests/suites/examples/transaction-buffer.ts
+++ b/tests/suites/examples/transaction-buffer.ts
@@ -18,7 +18,6 @@ import {
   VaultTransactionCreateFromBufferInstructionArgs,
 } from "@sqds/multisig/lib/generated";
 import assert from "assert";
-import { BN } from "bn.js";
 import * as crypto from "crypto";
 import {
   TestMembers,
@@ -74,6 +73,7 @@ describe("Examples / Transaction Buffers", () => {
 
   it("set buffer, extend, and create", async () => {
     const transactionIndex = 1n;
+    const bufferIndex = 0;
 
     const testIx = createTestTransferInstruction(vaultPda, vaultPda, 1);
 
@@ -103,7 +103,7 @@ describe("Examples / Transaction Buffers", () => {
         Buffer.from("multisig"),
         multisigPda.toBuffer(),
         Buffer.from("transaction_buffer"),
-        new BN(Number(transactionIndex)).toBuffer("le", 8),
+        Buffer.from([bufferIndex])
       ],
       programId
     );
@@ -122,10 +122,10 @@ describe("Examples / Transaction Buffers", () => {
         transactionBuffer,
         creator: members.almighty.publicKey,
         rentPayer: members.almighty.publicKey,
-        systemProgram: SystemProgram.programId,
       },
       {
         args: {
+          bufferIndex: bufferIndex,
           vaultIndex: 0,
           // Must be a SHA256 hash of the message buffer.
           finalBufferHash: Array.from(messageHash),

--- a/tests/suites/instructions/transactionBufferCreate.ts
+++ b/tests/suites/instructions/transactionBufferCreate.ts
@@ -2,12 +2,17 @@ import {
   Keypair,
   LAMPORTS_PER_SOL,
   PublicKey,
+  SystemProgram,
   TransactionMessage,
   VersionedTransaction,
-  SystemProgram,
 } from "@solana/web3.js";
 import * as multisig from "@sqds/multisig";
+import {
+  TransactionBufferCreateArgs,
+  TransactionBufferCreateInstructionArgs,
+} from "@sqds/multisig/lib/generated";
 import assert from "assert";
+import * as crypto from "crypto";
 import {
   createAutonomousMultisigV2,
   createLocalhostConnection,
@@ -16,12 +21,6 @@ import {
   getTestProgramId,
   TestMembers,
 } from "../../utils";
-import { BN } from "bn.js";
-import {
-  TransactionBufferCreateArgs,
-  TransactionBufferCreateInstructionArgs,
-} from "@sqds/multisig/lib/generated";
-import * as crypto from "crypto";
 
 const programId = getTestProgramId();
 const connection = createLocalhostConnection();
@@ -68,7 +67,7 @@ describe("Instructions / transaction_buffer_create", () => {
   });
 
   it("set transaction buffer", async () => {
-    const transactionIndex = 1n;
+    const bufferIndex = 0;
 
     const testPayee = Keypair.generate();
     const testIx = createTestTransferInstruction(
@@ -92,12 +91,12 @@ describe("Instructions / transaction_buffer_create", () => {
         vaultPda,
       });
 
-    const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
+    const [transactionBuffer, _] = PublicKey.findProgramAddressSync(
       [
         Buffer.from("multisig"),
         multisigPda.toBuffer(),
         Buffer.from("transaction_buffer"),
-        new BN(Number(transactionIndex)).toBuffer("le", 8),
+        Uint8Array.from([bufferIndex])
       ],
       programId
     );
@@ -107,6 +106,7 @@ describe("Instructions / transaction_buffer_create", () => {
       .createHash("sha256")
       .update(messageBuffer)
       .digest();
+
 
     const ix = multisig.generated.createTransactionBufferCreateInstruction(
       {
@@ -118,7 +118,9 @@ describe("Instructions / transaction_buffer_create", () => {
       },
       {
         args: {
+          bufferIndex: bufferIndex,
           vaultIndex: 0,
+          createKey: Keypair.generate(),
           // Must be a SHA256 hash of the message buffer.
           finalBufferHash: Array.from(messageHash),
           finalBufferSize: messageBuffer.length,
@@ -153,15 +155,17 @@ describe("Instructions / transaction_buffer_create", () => {
     assert.ok(transactionBufferAccount?.data.length! > 0);
   });
 
-  it("close transaction buffer", async () => {
-    const transactionIndex = 1n;
 
-    const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
+
+  it("close transaction buffer", async () => {
+    const bufferIndex = 0;
+
+    const [transactionBuffer, _] = PublicKey.findProgramAddressSync(
       [
         Buffer.from("multisig"),
         multisigPda.toBuffer(),
         Buffer.from("transaction_buffer"),
-        new BN(Number(transactionIndex)).toBuffer("le", 8),
+        Uint8Array.from([bufferIndex])
       ],
       programId
     );
@@ -199,330 +203,456 @@ describe("Instructions / transaction_buffer_create", () => {
     assert.equal(transactionBufferAccount, null);
   });
 
+  it("reinitalize transaction buffer after its been closed", async () => {
+    const bufferIndex = 0;
+
+    const testPayee = Keypair.generate();
+    const testIx = createTestTransferInstruction(
+      vaultPda,
+      testPayee.publicKey,
+      1 * LAMPORTS_PER_SOL
+    );
+
+    // Initialize a transaction message with a single instruction.
+    const testTransferMessage = new TransactionMessage({
+      payerKey: vaultPda,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [testIx],
+    });
+
+    // Serialize with SDK util
+    const messageBuffer =
+      multisig.utils.transactionMessageToMultisigTransactionMessageBytes({
+        message: testTransferMessage,
+        addressLookupTableAccounts: [],
+        vaultPda,
+      });
+
+    const [transactionBuffer, _] = PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("multisig"),
+        multisigPda.toBuffer(),
+        Buffer.from("transaction_buffer"),
+        Uint8Array.from([bufferIndex])
+      ],
+      programId
+    );
+
+    // Convert to a SHA256 hash.
+    const messageHash = crypto
+      .createHash("sha256")
+      .update(messageBuffer)
+      .digest();
+
+
+    const ix = multisig.generated.createTransactionBufferCreateInstruction(
+      {
+        multisig: multisigPda,
+        transactionBuffer,
+        creator: members.proposer.publicKey,
+        rentPayer: members.proposer.publicKey,
+        systemProgram: SystemProgram.programId,
+      },
+      {
+        args: {
+          bufferIndex: bufferIndex,
+          vaultIndex: 0,
+          createKey: Keypair.generate(),
+          // Must be a SHA256 hash of the message buffer.
+          finalBufferHash: Array.from(messageHash),
+          finalBufferSize: messageBuffer.length,
+          buffer: messageBuffer,
+        } as TransactionBufferCreateArgs,
+      } as TransactionBufferCreateInstructionArgs,
+      programId
+    );
+
+    const message = new TransactionMessage({
+      payerKey: members.proposer.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [ix],
+    }).compileToV0Message();
+
+    const tx = new VersionedTransaction(message);
+
+    tx.sign([members.proposer]);
+
+    // Send transaction.
+    const signature = await connection.sendTransaction(tx, {
+      skipPreflight: true,
+    });
+    await connection.confirmTransaction(signature);
+
+    const transactionBufferAccount = await connection.getAccountInfo(
+      transactionBuffer
+    );
+
+    // Verify account exists.
+    assert.notEqual(transactionBufferAccount, null);
+    assert.ok(transactionBufferAccount?.data.length! > 0);
+
+    const ix2 = multisig.generated.createTransactionBufferCloseInstruction(
+      {
+        multisig: multisigPda,
+        transactionBuffer,
+        creator: members.proposer.publicKey,
+      },
+      programId
+    );
+
+    const message2 = new TransactionMessage({
+      payerKey: members.proposer.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [ix2],
+    }).compileToV0Message();
+
+    const tx2 = new VersionedTransaction(message2);
+
+    tx2.sign([members.proposer]);
+
+    // Send transaction.
+    const signature2 = await connection.sendTransaction(tx2, {
+      skipPreflight: true,
+    });
+    await connection.confirmTransaction(signature2);
+
+    const transactionBufferAccount2 = await connection.getAccountInfo(
+      transactionBuffer
+    );
+
+    // Verify account is closed.
+    assert.equal(transactionBufferAccount2, null);
+  });
+
   // Test: Attempt to create a transaction buffer with a non-member
-it("error: creating buffer as non-member", async () => {
-  const transactionIndex = 1n;
-  // Create a keypair that is not a member of the multisig
-  const nonMember = Keypair.generate();
-  // Airdrop some SOL to the non-member
-  const airdropSig = await connection.requestAirdrop(
-    nonMember.publicKey,
-    1 * LAMPORTS_PER_SOL
-  );
-  await connection.confirmTransaction(airdropSig);
+  it("error: creating buffer as non-member", async () => {
+    const bufferIndex = 0;
+    // Create a keypair that is not a member of the multisig
+    const nonMember = Keypair.generate();
+    // Airdrop some SOL to the non-member
+    const airdropSig = await connection.requestAirdrop(
+      nonMember.publicKey,
+      1 * LAMPORTS_PER_SOL
+    );
+    await connection.confirmTransaction(airdropSig);
 
-  // Set up a test transaction
-  const testPayee = Keypair.generate();
-  const testIx = await createTestTransferInstruction(
-    vaultPda,
-    testPayee.publicKey,
-    1 * LAMPORTS_PER_SOL
-  );
-
-  // Create a transaction message
-  const testTransferMessage = new TransactionMessage({
-    payerKey: vaultPda,
-    recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    instructions: [testIx],
-  });
-
-  // Serialize the message buffer
-  const messageBuffer =
-    multisig.utils.transactionMessageToMultisigTransactionMessageBytes({
-      message: testTransferMessage,
-      addressLookupTableAccounts: [],
+    // Set up a test transaction
+    const testPayee = Keypair.generate();
+    const testIx = await createTestTransferInstruction(
       vaultPda,
+      testPayee.publicKey,
+      1 * LAMPORTS_PER_SOL
+    );
+
+    // Create a transaction message
+    const testTransferMessage = new TransactionMessage({
+      payerKey: vaultPda,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [testIx],
     });
 
-  // Derive the transaction buffer PDA
-  const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
-    [
-      Buffer.from("multisig"),
-      multisigPda.toBuffer(),
-      Buffer.from("transaction_buffer"),
-      new BN(Number(transactionIndex)).toBuffer("le", 8),
-    ],
-    programId
-  );
+    // Serialize the message buffer
+    const messageBuffer =
+      multisig.utils.transactionMessageToMultisigTransactionMessageBytes({
+        message: testTransferMessage,
+        addressLookupTableAccounts: [],
+        vaultPda,
+      });
 
-  // Create a hash of the message buffer
-  const messageHash = crypto
-    .createHash("sha256")
-    .update(messageBuffer)
-    .digest();
+    // Derive the transaction buffer PDA
+    const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("multisig"),
+        multisigPda.toBuffer(),
+        Buffer.from("transaction_buffer"),
+        Uint8Array.from([bufferIndex]),
+      ],
+      programId
+    );
 
-  // Create the instruction to create a transaction buffer
-  const ix = multisig.generated.createTransactionBufferCreateInstruction(
-    {
-      multisig: multisigPda,
-      transactionBuffer,
-      creator: nonMember.publicKey,
-      rentPayer: nonMember.publicKey,
-      systemProgram: SystemProgram.programId,
-    },
-    {
-      args: {
-        vaultIndex: 0,
-        finalBufferHash: Array.from(messageHash),
-        finalBufferSize: messageBuffer.length,
-        buffer: messageBuffer,
-      } as TransactionBufferCreateArgs,
-    } as TransactionBufferCreateInstructionArgs,
-    programId
-  );
+    // Create a hash of the message buffer
+    const messageHash = crypto
+      .createHash("sha256")
+      .update(messageBuffer)
+      .digest();
 
-  // Create and sign the transaction
-  const message = new TransactionMessage({
-    payerKey: nonMember.publicKey,
-    recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    instructions: [ix],
-  }).compileToV0Message();
+    // Create the instruction to create a transaction buffer
+    const ix = multisig.generated.createTransactionBufferCreateInstruction(
+      {
+        multisig: multisigPda,
+        transactionBuffer,
+        creator: nonMember.publicKey,
+        rentPayer: nonMember.publicKey,
+        systemProgram: SystemProgram.programId,
+      },
+      {
+        args: {
+          bufferIndex: bufferIndex,
+          vaultIndex: 0,
+          finalBufferHash: Array.from(messageHash),
+          finalBufferSize: messageBuffer.length,
+          buffer: messageBuffer,
+        } as TransactionBufferCreateArgs,
+      } as TransactionBufferCreateInstructionArgs,
+      programId
+    );
 
-  const tx = new VersionedTransaction(message);
-  tx.sign([nonMember]);
+    // Create and sign the transaction
+    const message = new TransactionMessage({
+      payerKey: nonMember.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [ix],
+    }).compileToV0Message();
 
-  // Attempt to send the transaction and expect it to fail
-  await assert.rejects(
-    () =>
-      connection
-        .sendTransaction(tx)
-        .catch(multisig.errors.translateAndThrowAnchorError),
-    /NotAMember/
-  );
-});
+    const tx = new VersionedTransaction(message);
+    tx.sign([nonMember]);
 
-// Test: Attempt to create a transaction buffer with a member without initiate permissions
-it("error: creating buffer as member without proposer permissions", async () => {
-  const memberWithoutInitiatePermissions = members.voter;
-
-  const transactionIndex = 1n;
-
-  // Set up a test transaction
-  const testPayee = Keypair.generate();
-  const testIx = await createTestTransferInstruction(
-    vaultPda,
-    testPayee.publicKey,
-    1 * LAMPORTS_PER_SOL
-  );
-
-  // Create a transaction message
-  const testTransferMessage = new TransactionMessage({
-    payerKey: vaultPda,
-    recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    instructions: [testIx],
+    // Attempt to send the transaction and expect it to fail
+    await assert.rejects(
+      () =>
+        connection
+          .sendTransaction(tx)
+          .catch(multisig.errors.translateAndThrowAnchorError),
+      /NotAMember/
+    );
   });
 
-  // Serialize the message buffer
-  const messageBuffer =
-    multisig.utils.transactionMessageToMultisigTransactionMessageBytes({
-      message: testTransferMessage,
-      addressLookupTableAccounts: [],
+  // Test: Attempt to create a transaction buffer with a member without initiate permissions
+  it("error: creating buffer as member without proposer permissions", async () => {
+    const memberWithoutInitiatePermissions = members.voter;
+
+    const bufferIndex = 0;
+
+    // Set up a test transaction
+    const testPayee = Keypair.generate();
+    const testIx = await createTestTransferInstruction(
       vaultPda,
+      testPayee.publicKey,
+      1 * LAMPORTS_PER_SOL
+    );
+
+    // Create a transaction message
+    const testTransferMessage = new TransactionMessage({
+      payerKey: vaultPda,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [testIx],
     });
 
-  // Derive the transaction buffer PDA
-  const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
-    [
-      Buffer.from("multisig"),
-      multisigPda.toBuffer(),
-      Buffer.from("transaction_buffer"),
-      new BN(Number(transactionIndex)).toBuffer("le", 8),
-    ],
-    programId
-  );
+    // Serialize the message buffer
+    const messageBuffer =
+      multisig.utils.transactionMessageToMultisigTransactionMessageBytes({
+        message: testTransferMessage,
+        addressLookupTableAccounts: [],
+        vaultPda,
+      });
 
-  // Create a hash of the message buffer
-  const messageHash = crypto
-    .createHash("sha256")
-    .update(messageBuffer)
-    .digest();
+    // Derive the transaction buffer PDA
+    const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("multisig"),
+        multisigPda.toBuffer(),
+        Buffer.from("transaction_buffer"),
+        Uint8Array.from([bufferIndex]),
+      ],
+      programId
+    );
 
-  // Create the instruction to create a transaction buffer
-  const ix = multisig.generated.createTransactionBufferCreateInstruction(
-    {
-      multisig: multisigPda,
-      transactionBuffer,
-      creator: memberWithoutInitiatePermissions.publicKey,
-      rentPayer: memberWithoutInitiatePermissions.publicKey,
-      systemProgram: SystemProgram.programId,
-    },
-    {
-      args: {
-        vaultIndex: 0,
-        finalBufferHash: Array.from(messageHash),
-        finalBufferSize: messageBuffer.length,
-        buffer: messageBuffer,
-      } as TransactionBufferCreateArgs,
-    } as TransactionBufferCreateInstructionArgs,
-    programId
-  );
+    // Create a hash of the message buffer
+    const messageHash = crypto
+      .createHash("sha256")
+      .update(messageBuffer)
+      .digest();
 
-  // Create and sign the transaction
-  const message = new TransactionMessage({
-    payerKey: memberWithoutInitiatePermissions.publicKey,
-    recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    instructions: [ix],
-  }).compileToV0Message();
+    // Create the instruction to create a transaction buffer
+    const ix = multisig.generated.createTransactionBufferCreateInstruction(
+      {
+        multisig: multisigPda,
+        transactionBuffer,
+        creator: memberWithoutInitiatePermissions.publicKey,
+        rentPayer: memberWithoutInitiatePermissions.publicKey,
+        systemProgram: SystemProgram.programId,
+      },
+      {
+        args: {
+          bufferIndex: bufferIndex,
+          vaultIndex: 0,
+          finalBufferHash: Array.from(messageHash),
+          finalBufferSize: messageBuffer.length,
+          buffer: messageBuffer,
+        } as TransactionBufferCreateArgs,
+      } as TransactionBufferCreateInstructionArgs,
+      programId
+    );
 
-  const tx = new VersionedTransaction(message);
-  tx.sign([memberWithoutInitiatePermissions]);
+    // Create and sign the transaction
+    const message = new TransactionMessage({
+      payerKey: memberWithoutInitiatePermissions.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [ix],
+    }).compileToV0Message();
 
-  // Attempt to send the transaction and expect it to fail
-  await assert.rejects(
-    () =>
-      connection
-        .sendTransaction(tx)
-        .catch(multisig.errors.translateAndThrowAnchorError),
-    /Unauthorized/
-  );
-});
+    const tx = new VersionedTransaction(message);
+    tx.sign([memberWithoutInitiatePermissions]);
 
-// Test: Attempt to create a transaction buffer with an invalid index
-it("error: creating buffer for invalid index", async () => {
-  // Use an invalid transaction index (multisig.transaction_index + 2)
-  const invalidTransactionIndex = 3n;
-
-  // Set up a test transaction
-  const testPayee = Keypair.generate();
-  const testIx = await createTestTransferInstruction(
-    vaultPda,
-    testPayee.publicKey,
-    1 * LAMPORTS_PER_SOL
-  );
-
-  // Create a transaction message
-  const testTransferMessage = new TransactionMessage({
-    payerKey: vaultPda,
-    recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    instructions: [testIx],
+    // Attempt to send the transaction and expect it to fail
+    await assert.rejects(
+      () =>
+        connection
+          .sendTransaction(tx)
+          .catch(multisig.errors.translateAndThrowAnchorError),
+      /Unauthorized/
+    );
   });
 
-  // Serialize the message buffer
-  const messageBuffer =
-    multisig.utils.transactionMessageToMultisigTransactionMessageBytes({
-      message: testTransferMessage,
-      addressLookupTableAccounts: [],
+  // Test: Attempt to create a transaction buffer with an invalid index
+  it("error: creating buffer for invalid index", async () => {
+    // Use an invalid buffer index (non-u8 value)
+    const invalidBufferIndex = "random_string";
+
+    // Set up a test transaction
+    const testPayee = Keypair.generate();
+    const testIx = await createTestTransferInstruction(
       vaultPda,
+      testPayee.publicKey,
+      1 * LAMPORTS_PER_SOL
+    );
+
+    // Create a transaction message
+    const testTransferMessage = new TransactionMessage({
+      payerKey: vaultPda,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [testIx],
     });
 
-  // Derive the transaction buffer PDA with the invalid index
-  const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
-    [
-      Buffer.from("multisig"),
-      multisigPda.toBuffer(),
-      Buffer.from("transaction_buffer"),
-      new BN(Number(invalidTransactionIndex)).toBuffer("le", 8),
-    ],
-    programId
-  );
+    // Serialize the message buffer
+    const messageBuffer =
+      multisig.utils.transactionMessageToMultisigTransactionMessageBytes({
+        message: testTransferMessage,
+        addressLookupTableAccounts: [],
+        vaultPda,
+      });
 
-  // Create a hash of the message buffer
-  const messageHash = crypto
-    .createHash("sha256")
-    .update(messageBuffer)
-    .digest();
+    // Derive the transaction buffer PDA with the invalid index
+    const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("multisig"),
+        multisigPda.toBuffer(),
+        Buffer.from("transaction_buffer"),
+        Buffer.from(invalidBufferIndex),
+      ],
+      programId
+    );
 
-  // Create the instruction to create a transaction buffer
-  const ix = multisig.generated.createTransactionBufferCreateInstruction(
-    {
-      multisig: multisigPda,
-      transactionBuffer,
-      creator: members.proposer.publicKey,
-      rentPayer: members.proposer.publicKey,
-      systemProgram: SystemProgram.programId,
-    },
-    {
-      args: {
-        vaultIndex: 0,
-        finalBufferHash: Array.from(messageHash),
-        finalBufferSize: messageBuffer.length,
-        buffer: messageBuffer,
-      } as TransactionBufferCreateArgs,
-    } as TransactionBufferCreateInstructionArgs,
-    programId
-  );
+    // Create a hash of the message buffer
+    const messageHash = crypto
+      .createHash("sha256")
+      .update(messageBuffer)
+      .digest();
 
-  // Create and sign the transaction
-  const message = new TransactionMessage({
-    payerKey: members.proposer.publicKey,
-    recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    instructions: [ix],
-  }).compileToV0Message();
+    // Create the instruction to create a transaction buffer
+    const ix = multisig.generated.createTransactionBufferCreateInstruction(
+      {
+        multisig: multisigPda,
+        transactionBuffer,
+        creator: members.proposer.publicKey,
+        rentPayer: members.proposer.publicKey,
+        systemProgram: SystemProgram.programId,
+      },
+      {
+        args: {
+          bufferIndex: 0,
+          vaultIndex: 0,
+          finalBufferHash: Array.from(messageHash),
+          finalBufferSize: messageBuffer.length,
+          buffer: messageBuffer,
+        } as TransactionBufferCreateArgs,
+      } as TransactionBufferCreateInstructionArgs,
+      programId
+    );
 
-  const tx = new VersionedTransaction(message);
-  tx.sign([members.proposer]);
+    // Create and sign the transaction
+    const message = new TransactionMessage({
+      payerKey: members.proposer.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [ix],
+    }).compileToV0Message();
 
-  // Attempt to send the transaction and expect it to fail
-  await assert.rejects(
-    () =>
-      connection
-        .sendTransaction(tx)
-        .catch(multisig.errors.translateAndThrowAnchorError),
-    /A seeds constraint was violated/
-  );
-});
+    const tx = new VersionedTransaction(message);
+    // Not signing with the create_key on purpose
+    tx.sign([members.proposer]);
+
+    // Attempt to send the transaction and expect it to fail
+    await assert.rejects(
+      () =>
+        connection
+          .sendTransaction(tx)
+          .catch(multisig.errors.translateAndThrowAnchorError),
+      /A seeds constraint was violated/
+    );
+  });
 
 
-it("error: creating buffer exceeding maximum size", async () => {
-  const transactionIndex = 1n;
+  it("error: creating buffer exceeding maximum size", async () => {
+    const bufferIndex = 0;
 
-  // Create a large buffer that exceeds the maximum size
-  const largeBuffer = Buffer.alloc(500, 1);  // 500 bytes, filled with 1s
+    // Create a large buffer that exceeds the maximum size
+    const largeBuffer = Buffer.alloc(500, 1);  // 500 bytes, filled with 1s
 
-  // Derive the transaction buffer PDA
-  const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
-    [
-      Buffer.from("multisig"),
-      multisigPda.toBuffer(),
-      Buffer.from("transaction_buffer"),
-      new BN(Number(transactionIndex)).toBuffer("le", 8),
-    ],
-    programId
-  );
+    // Derive the transaction buffer PDA
+    const [transactionBuffer, _] = await PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("multisig"),
+        multisigPda.toBuffer(),
+        Buffer.from("transaction_buffer"),
+        Uint8Array.from([bufferIndex]),
+      ],
+      programId
+    );
 
-  // Create a hash of the large buffer
-  const messageHash = crypto
-    .createHash("sha256")
-    .update(largeBuffer)
-    .digest();
+    // Create a hash of the large buffer
+    const messageHash = crypto
+      .createHash("sha256")
+      .update(largeBuffer)
+      .digest();
 
-  // Create the instruction to create a transaction buffer
-  const ix = multisig.generated.createTransactionBufferCreateInstruction(
-    {
-      multisig: multisigPda,
-      transactionBuffer,
-      creator: members.proposer.publicKey,
-      rentPayer: members.proposer.publicKey,
-      systemProgram: SystemProgram.programId,
-    },
-    {
-      args: {
-        vaultIndex: 0,
-        finalBufferHash: Array.from(messageHash),
-        finalBufferSize: 4001,
-        buffer: largeBuffer,
-      } as TransactionBufferCreateArgs,
-    } as TransactionBufferCreateInstructionArgs,
-    programId
-  );  
+    // Create the instruction to create a transaction buffer
+    const ix = multisig.generated.createTransactionBufferCreateInstruction(
+      {
+        multisig: multisigPda,
+        transactionBuffer,
+        creator: members.proposer.publicKey,
+        rentPayer: members.proposer.publicKey,
+        systemProgram: SystemProgram.programId,
+      },
+      {
+        args: {
+          bufferIndex: bufferIndex,
+          vaultIndex: 0,
+          finalBufferHash: Array.from(messageHash),
+          finalBufferSize: 4001,
+          buffer: largeBuffer,
+        } as TransactionBufferCreateArgs,
+      } as TransactionBufferCreateInstructionArgs,
+      programId
+    );
 
-  // Create and sign the transaction
-  const message = new TransactionMessage({
-    payerKey: members.proposer.publicKey,
-    recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    instructions: [ix],
-  }).compileToV0Message();
+    // Create and sign the transaction
+    const message = new TransactionMessage({
+      payerKey: members.proposer.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+      instructions: [ix],
+    }).compileToV0Message();
 
-  const tx = new VersionedTransaction(message);
-  tx.sign([members.proposer]);
+    const tx = new VersionedTransaction(message);
+    tx.sign([members.proposer]);
 
-  // Attempt to send the transaction and expect it to fail
-  await assert.rejects(
-    () =>
-      connection
-        .sendTransaction(tx)
-        .catch(multisig.errors.translateAndThrowAnchorError),
-    /FinalBufferSizeExceeded/  // Assuming this is the error thrown for exceeding buffer size
-  );
-});
+    // Attempt to send the transaction and expect it to fail
+    await assert.rejects(
+      () =>
+        connection
+          .sendTransaction(tx)
+          .catch(multisig.errors.translateAndThrowAnchorError),
+      /FinalBufferSizeExceeded/  // Assuming this is the error thrown for exceeding buffer size
+    );
+  });
 });

--- a/tests/suites/instructions/transactionBufferExtend.ts
+++ b/tests/suites/instructions/transactionBufferExtend.ts
@@ -14,7 +14,6 @@ import {
   TransactionBufferExtendInstructionArgs,
 } from "@sqds/multisig/lib/generated";
 import assert from "assert";
-import { BN } from "bn.js";
 import * as crypto from "crypto";
 import {
   TestMembers,
@@ -75,7 +74,7 @@ describe("Instructions / transaction_buffer_extend", () => {
         Buffer.from("multisig"),
         multisigPda.toBuffer(),
         Buffer.from("transaction_buffer"),
-        new BN(Number(transactionIndex)).toBuffer("le", 8),
+        Buffer.from([Number(transactionIndex)])
       ],
       programId
     );
@@ -110,6 +109,7 @@ describe("Instructions / transaction_buffer_extend", () => {
       },
       {
         args: {
+          bufferIndex: Number(transactionIndex),
           vaultIndex: 0,
           finalBufferHash: Array.from(messageHash),
           finalBufferSize: messageBuffer.length,
@@ -194,7 +194,7 @@ describe("Instructions / transaction_buffer_extend", () => {
         Buffer.from("multisig"),
         multisigPda.toBuffer(),
         Buffer.from("transaction_buffer"),
-        new BN(Number(transactionIndex)).toBuffer("le", 8),
+        Buffer.from([Number(transactionIndex)])
       ],
       programId
     );
@@ -217,6 +217,7 @@ describe("Instructions / transaction_buffer_extend", () => {
       },
       {
         args: {
+          bufferIndex: Number(transactionIndex),
           vaultIndex: 0,
           // Must be a SHA256 hash of the message buffer.
           finalBufferHash: Array.from(messageHash),
@@ -241,6 +242,7 @@ describe("Instructions / transaction_buffer_extend", () => {
     const signature = await connection.sendTransaction(tx, {
       skipPreflight: true,
     });
+
     await connection.confirmTransaction(signature);
 
     const transactionBufferAccount = await connection.getAccountInfo(

--- a/tests/suites/instructions/vaultTransactionCreateFromBuffer.ts
+++ b/tests/suites/instructions/vaultTransactionCreateFromBuffer.ts
@@ -74,9 +74,10 @@ describe("Instructions / vault_transaction_create_from_buffer", () => {
 
   it("set buffer, extend, and create", async () => {
     const transactionIndex = 1n;
+    const bufferIndex = 0;
 
     const testPayee = Keypair.generate();
-    const testIx = await createTestTransferInstruction(
+    const testIx = createTestTransferInstruction(
       vaultPda,
       testPayee.publicKey,
       1 * LAMPORTS_PER_SOL
@@ -109,7 +110,7 @@ describe("Instructions / vault_transaction_create_from_buffer", () => {
         Buffer.from("multisig"),
         multisigPda.toBuffer(),
         Buffer.from("transaction_buffer"),
-        new BN(Number(transactionIndex)).toBuffer("le", 8),
+        Uint8Array.from([bufferIndex]),
       ],
       programId
     );
@@ -132,6 +133,7 @@ describe("Instructions / vault_transaction_create_from_buffer", () => {
       },
       {
         args: {
+          bufferIndex: bufferIndex,
           vaultIndex: 0,
           // Must be a SHA256 hash of the message buffer.
           finalBufferHash: Array.from(messageHash),
@@ -156,7 +158,6 @@ describe("Instructions / vault_transaction_create_from_buffer", () => {
     const signature = await connection.sendTransaction(tx, {
       skipPreflight: true,
     });
-
     await connection.confirmTransaction(signature);
 
     const transactionBufferAccount = await connection.getAccountInfo(
@@ -248,17 +249,7 @@ describe("Instructions / vault_transaction_create_from_buffer", () => {
       toPubkey: members.almighty.publicKey,
       lamports: 100
     });
-    // const mockTransferMessage = new TransactionMessage({
-    //   payerKey: vaultPda,
-    //   recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    //   instructions: [mockTransferIx],
-    // });
 
-    // const bytes = multisig.utils.transactionMessageToMultisigTransactionMessageBytes({
-    //   message: mockTransferMessage,
-    //   addressLookupTableAccounts: [],
-    //   vaultPda,
-    // });
 
     // Create final instruction.
     const thirdIx =
@@ -319,6 +310,7 @@ describe("Instructions / vault_transaction_create_from_buffer", () => {
 
   it("error: create from buffer with mismatched hash", async () => {
     const transactionIndex = 2n;
+    const bufferIndex = 0;
 
     // Create a simple transfer instruction
     const testIx = await createTestTransferInstruction(
@@ -346,7 +338,7 @@ describe("Instructions / vault_transaction_create_from_buffer", () => {
         Buffer.from("multisig"),
         multisigPda.toBuffer(),
         Buffer.from("transaction_buffer"),
-        new BN(Number(transactionIndex)).toBuffer("le", 8),
+        Uint8Array.from([bufferIndex]),
       ],
       programId
     );
@@ -365,6 +357,7 @@ describe("Instructions / vault_transaction_create_from_buffer", () => {
         },
         {
           args: {
+            bufferIndex,
             vaultIndex: 0,
             finalBufferHash: Array.from(dummyHash),
             finalBufferSize: messageBuffer.length,


### PR DESCRIPTION
This PR includes the following commits:

- [0996f21 - refactor: lamport mutation into system transfer](https://github.com/Squads-Protocol/v4/commit/0996f21b1bec77c73dc1c2be44a37ca62c4af504)

- [ca85338 - feat: u8 for buffer seeding](https://github.com/Squads-Protocol/v4/commit/ca85338f6cfcfd619a1b4f5570f53d3d6d2d4335)

`0996f21` changes the original lamport mutation into a regular system transfer. The lamport mutation works, but its unclear why, when examining the runtime guarantee that program XYZ should only be able to borrow lamports from an account owned by program XYZ. In the original state we were able to borrow lamports from an account owned by the system program. The system transfer is safer, should the original behavior turn out to be unintended.

`ca85338` refactors the seed constraint for the `transaction_buffer` account. It now uses a u8 for derivation instead of tying it to the multisigs `transaction_index`. It allows a creator to have up to 255 concurrent buffers open.  In contrast to using a `create_key` this improves indexability and saves us the overhead of having to pass 32 bytes for the account and an additional 64 byte signature. 