### PR TITLE
feat(cli-vault): command show to vaults by index

### DIFF
--- a/cli/src/command/display_vault.rs
+++ b/cli/src/command/display_vault.rs
@@ -1,0 +1,46 @@
+use squads_multisig::pda::get_vault_pda;
+use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
+
+use clap::Args;
+
+#[derive(Args)]
+pub struct DisplayVault {
+    /// Multisig Program ID
+    #[arg(long)]
+    program_id: Option<String>,
+
+    /// Path to the Program Config Initializer Keypair
+    #[arg(long)]
+    multisig_address: String,
+
+    // index to derive the vault, default 0
+    #[arg(long)]
+    vault_index: Option<u8>,
+}
+
+impl DisplayVault {
+    pub async fn execute(self) -> eyre::Result<()> {
+        let Self {
+            program_id,
+            multisig_address,
+            vault_index,
+        } = self;
+
+        let program_id = program_id.unwrap_or_else(|| {
+            "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf".to_string()
+        });
+
+        let program_id = Pubkey::from_str(&program_id).expect("Invalid program ID");
+
+        let multisig_address = Pubkey::from_str(&multisig_address).expect("Invalid multisig address");
+
+        let vault_index = vault_index.unwrap_or(0);
+
+        let vault_address = get_vault_pda(&multisig_address, vault_index, Some(&program_id));
+
+        println!("Vault: {:?}", vault_address);
+
+        Ok(())
+    }
+}

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -8,6 +8,7 @@ use crate::command::proposal_vote::ProposalVote;
 use crate::command::vault_transaction_accounts_close::VaultTransactionAccountsClose;
 use crate::command::vault_transaction_create::VaultTransactionCreate;
 use crate::command::vault_transaction_execute::VaultTransactionExecute;
+use crate::command::display_vault::DisplayVault;
 
 use clap::Subcommand;
 
@@ -21,6 +22,7 @@ pub mod proposal_vote;
 pub mod vault_transaction_accounts_close;
 pub mod vault_transaction_create;
 pub mod vault_transaction_execute;
+pub mod display_vault;
 
 #[derive(Subcommand)]
 pub enum Command {
@@ -34,4 +36,5 @@ pub enum Command {
     VaultTransactionAccountsClose(VaultTransactionAccountsClose),
     InitiateTransfer(InitiateTransfer),
     InitiateProgramUpgrade(InitiateProgramUpgrade),
+    DisplayVault(DisplayVault),
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -26,5 +26,6 @@ async fn main() -> eyre::Result<()> {
         Command::VaultTransactionAccountsClose(command) => command.execute().await,
         Command::InitiateTransfer(command) => command.execute().await,
         Command::InitiateProgramUpgrade(command) => command.execute().await,
+        Command::DisplayVault(command) => command.execute().await,
     }
 }


### PR DESCRIPTION
Added a command to derive and show vault address by supplied squad base address and vault index.