### PR TITLE
fix(rs-sdk): remove deprecated multisig_create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "squads-multisig"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "futures",
  "solana-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "squads-multisig"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "futures",
  "solana-client",

--- a/sdk/rs/Cargo.toml
+++ b/sdk/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squads-multisig"
-version = "2.0.2"
+version = "2.1.0"
 description = "An SDK for building automated programs on Solana"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/sdk/rs/Cargo.toml
+++ b/sdk/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squads-multisig"
-version = "2.0.1"
+version = "2.0.2"
 description = "An SDK for building automated programs on Solana"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/sdk/rs/src/client.rs
+++ b/sdk/rs/src/client.rs
@@ -4,7 +4,6 @@ pub use squads_multisig_program::accounts::BatchAccountsClose as BatchAccountsCl
 pub use squads_multisig_program::accounts::ConfigTransactionAccountsClose as ConfigTransactionAccountsCloseAccounts;
 pub use squads_multisig_program::accounts::ConfigTransactionCreate as ConfigTransactionCreateAccounts;
 pub use squads_multisig_program::accounts::ConfigTransactionExecute as ConfigTransactionExecuteAccounts;
-pub use squads_multisig_program::accounts::MultisigCreate as MultisigCreateAccounts;
 pub use squads_multisig_program::accounts::MultisigCreateV2 as MultisigCreateAccountsV2;
 pub use squads_multisig_program::accounts::ProposalCreate as ProposalCreateAccounts;
 pub use squads_multisig_program::accounts::ProposalVote as ProposalVoteAccounts;
@@ -27,7 +26,6 @@ pub use squads_multisig_program::instruction::VaultTransactionAccountsClose as V
 pub use squads_multisig_program::instruction::VaultTransactionCreate as VaultTransactionCreateData;
 pub use squads_multisig_program::instruction::VaultTransactionExecute as VaultTransactionExecuteData;
 pub use squads_multisig_program::instructions::ConfigTransactionCreateArgs;
-pub use squads_multisig_program::instructions::MultisigCreateArgs;
 pub use squads_multisig_program::instructions::MultisigCreateArgsV2;
 pub use squads_multisig_program::instructions::ProposalCreateArgs;
 pub use squads_multisig_program::instructions::ProposalVoteArgs;
@@ -71,54 +69,6 @@ pub async fn get_spending_limit(
             .map_err(|_| ClientError::DeserializationError)?;
 
     Ok(spending_limit)
-}
-
-/// Creates a new multisig config transaction.
-/// Example:
-/// ```
-/// use squads_multisig::anchor_lang::error::ComparedValues::Pubkeys;
-/// use squads_multisig::solana_program::pubkey::Pubkey;
-/// use squads_multisig::solana_program::system_program;
-/// use squads_multisig::state::{ConfigAction, Member, Permissions, Permission};
-/// use squads_multisig::client::{
-///     MultisigCreateAccounts,
-///     MultisigCreateArgs,
-///     multisig_create
-/// };
-///
-/// let ix = multisig_create(
-///     MultisigCreateAccounts {
-///         multisig: Pubkey::new_unique(),
-///         create_key: Pubkey::new_unique(),
-///         creator: Pubkey::new_unique(),
-///         system_program: system_program::id(),
-///     },
-///     MultisigCreateArgs {
-///         members: vec![
-///             Member {
-///                 key: Pubkey::new_unique(),
-///                 permissions: Permissions::from_vec(&[Permission::Initiate, Permission::Vote, Permission::Execute]),
-///             }
-///         ],
-///         threshold: 1,
-///         time_lock: 0,
-///         config_authority: None,
-///         memo: Some("Deploy my own Squad".to_string()),
-///     },
-///     Some(squads_multisig_program::ID)
-/// );
-/// ```
-///
-pub fn multisig_create(
-    accounts: MultisigCreateAccounts,
-    args: MultisigCreateArgs,
-    program_id: Option<Pubkey>,
-) -> Instruction {
-    Instruction {
-        accounts: accounts.to_account_metas(Some(false)),
-        data: MultisigCreateData { args }.data(),
-        program_id: program_id.unwrap_or(squads_multisig_program::ID),
-    }
 }
 
 /// Creates a new multisig config transaction.

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -41,26 +41,28 @@ pub mod cpi {
     use squads_multisig_program::anchor_lang::prelude::{CpiContext, Pubkey, Result};
     pub use squads_multisig_program::cpi::accounts::{
         BatchAddTransaction, BatchCreate, BatchExecuteTransaction, ConfigTransactionCreate,
-        ConfigTransactionExecute, MultisigAddSpendingLimit, MultisigConfig, MultisigCreate,
+        ConfigTransactionExecute, MultisigAddSpendingLimit, MultisigConfig, MultisigCreateV2,
         MultisigRemoveSpendingLimit, ProposalActivate, ProposalCreate, ProposalVote,
         SpendingLimitUse, VaultTransactionCreate, VaultTransactionExecute,
     };
     use squads_multisig_program::Member;
 
     pub fn create_multisig<'info>(
-        ctx: CpiContext<'_, '_, '_, 'info, MultisigCreate<'info>>,
+        ctx: CpiContext<'_, '_, '_, 'info, MultisigCreateV2<'info>>,
         members: Vec<Member>,
         threshold: u16,
         config_authority: Option<Pubkey>,
+        rent_collector: Option<Pubkey>,
         time_lock: u32,
         memo: Option<String>,
     ) -> Result<()> {
-        squads_multisig_program::cpi::multisig_create(
+        squads_multisig_program::cpi::multisig_create_v2(
             ctx,
-            squads_multisig_program::MultisigCreateArgs {
+            squads_multisig_program::MultisigCreateArgsV2 {
                 members,
                 threshold,
                 config_authority,
+                rent_collector,
                 time_lock,
                 memo,
             },


### PR DESCRIPTION
Since `multisig_create` has officially been removed in favor of `multisig_create_v2`, it needs to be removed from the SDK to fix build issues