### PR TITLE
Update readme to include Neodyme audit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,10 @@ Below is a list of audit reports pertaining to the v4 program. Each entry enumer
 - Ottersec 2024 Final: [View full
   report](https://github.com/Squads-Protocol/v4/blob/main/audits/ottersec_squads_v4_audit_2024_final.pdf)
 - Neodyme: [View full report](https://github.com/Squads-Protocol/v4/blob/main/audits/neodyme_squads_v4_report.pdf)
-- Neodyme 2024: [View full report](https://github.com/Squads-Protocol/v4/blob/main/audits/neodyme_squads_v4_report_2024.pdf)
+- Neodyme 2024: [View full
+  report](https://github.com/Squads-Protocol/v4/blob/main/audits/neodyme_squads_v4_report_2024.pdf)
+- Neodyme 2024 Final: [View full
+  report](https://github.com/Squads-Protocol/v4/blob/main/audits/neodyme_squads_v4_report_2024_final.pdf)
 - Certora + Formal verification: [View full report](https://github.com/Squads-Protocol/v4/blob/main/audits/certora_squads_v4_security_report_and_formal_verification.pdf)
 - Certora Audit + Formal Verification (December 2023): [View full
   report](https://github.com/Squads-Protocol/v4/blob/main/audits/certora_squads_v4_security_report_and_formal_verification_2024.pdf)


### PR DESCRIPTION
Adds the link to the final Neodyme audit into `README.md`. 
Was meant to be included as part of  #142.