### PR TITLE
Add optional create_key arg to multisig-create

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -2,13 +2,20 @@ use clap_v3::ArgMatches;
 use colored::Colorize;
 use eyre::eyre;
 use solana_clap_v3_utils::keypair::signer_from_path;
-use solana_sdk::{signer::Signer, transaction::VersionedTransaction};
+use solana_sdk::signature::read_keypair_file;
+use solana_sdk::{signer::keypair::Keypair, signer::Signer, transaction::VersionedTransaction};
 use squads_multisig::solana_client::nonblocking::rpc_client::RpcClient;
 use squads_multisig::solana_client::{
     client_error::ClientErrorKind,
     rpc_request::{RpcError, RpcResponseErrorData},
     rpc_response::RpcSimulateTransactionResult,
 };
+
+pub fn create_keypair_from_path(
+    keypair_path: String,
+) -> Result<Keypair, Box<dyn std::error::Error>> {
+    read_keypair_file(&keypair_path).map_err(|e| e.into())
+}
 
 pub fn create_signer_from_path(
     keypair_path: String,


### PR DESCRIPTION
This is handy to get deterministic multisigs across networks for testing / training purposes, see 
[devnet tx](https://explorer.solana.com/tx/51d7nLEQLA1QYStZBTAL2FbxQSVsQucuHYzvxMyNLF3d6dYJ4j76zTx9RFk9F2iYE1o59rGMij7yL1ZUARWH6QQk?cluster=devnet)
[mainnet tx](https://explorer.solana.com/tx/3resF6JvTR5LxPAV2mJJDpyjRasbSvDSuBFFAo2QApT59VRAnac16KTCrrNpzjPDZpLHzpVGbMzpkyNYk2CZqNNo)