### PR TITLE
@sqds/multisig: optional addressLookupTableAccounts arg for accountsForTransactionExecute

### DIFF
--- a/sdk/multisig/src/utils.ts
+++ b/sdk/multisig/src/utils.ts
@@ -183,7 +183,7 @@ export async function accountsForTransactionExecute({
     await Promise.all(
       addressLookupTableKeys.map(async (key) => {
         const keyBase58 = key.toBase58();
-        const localAccount = offlineAddressLookupTableAccounts?.find((a) => a.key.toBase58() === keyBase58)
+        const localAccount = localAddressLookupTableAccounts?.find((a) => a.key.toBase58() === keyBase58)
         if (localAccount) {
           return [keyBase58, localAccount];
         }

--- a/sdk/multisig/src/utils.ts
+++ b/sdk/multisig/src/utils.ts
@@ -151,6 +151,7 @@ export async function accountsForTransactionExecute({
   message,
   ephemeralSignerBumps,
   programId,
+  addressLookupTableAccounts: localAddressLookupTableAccounts,
 }: {
   connection: Connection;
   message: VaultTransactionMessage;
@@ -158,6 +159,7 @@ export async function accountsForTransactionExecute({
   vaultPda: PublicKey;
   transactionPda: PublicKey;
   programId?: PublicKey;
+  addressLookupTableAccounts?: AddressLookupTableAccount[];
 }): Promise<{
   /** Account metas used in the `message`. */
   accountMetas: AccountMeta[];
@@ -180,13 +182,19 @@ export async function accountsForTransactionExecute({
   const addressLookupTableAccounts = new Map(
     await Promise.all(
       addressLookupTableKeys.map(async (key) => {
+        const keyBase58 = key.toBase58();
+        const localAccount = offlineAddressLookupTableAccounts?.find((a) => a.key.toBase58() === keyBase58)
+        if (localAccount) {
+          return [keyBase58, localAccount];
+        }
+
         const { value } = await connection.getAddressLookupTable(key);
         if (!value) {
           throw new Error(
-            `Address lookup table account ${key.toBase58()} not found`
+            `Address lookup table account ${keyBase58} not found`
           );
         }
-        return [key.toBase58(), value] as const;
+        return [keyBase58, value] as const;
       })
     )
   );


### PR DESCRIPTION
Currently lookup table accounts must exist on-chain before `multisig.utils.accountsForTransactionExecute` can be called. 
This would allow passing accounts in locally before they exist on-chain.