### PR TITLE
feat(cli): Add possibility to use an extra signer for vault tx execution

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4460,7 +4460,7 @@ dependencies = [
 
 [[package]]
 name = "squads-multisig"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "futures",
  "solana-client",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "squads-multisig-program"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/cli/src/command/display_vault.rs
+++ b/cli/src/command/display_vault.rs
@@ -1,5 +1,5 @@
-use squads_multisig::pda::get_vault_pda;
 use solana_sdk::pubkey::Pubkey;
+use squads_multisig::pda::get_vault_pda;
 use std::str::FromStr;
 
 use clap::Args;
@@ -27,13 +27,13 @@ impl DisplayVault {
             vault_index,
         } = self;
 
-        let program_id = program_id.unwrap_or_else(|| {
-            "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf".to_string()
-        });
+        let program_id =
+            program_id.unwrap_or_else(|| "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf".to_string());
 
         let program_id = Pubkey::from_str(&program_id).expect("Invalid program ID");
 
-        let multisig_address = Pubkey::from_str(&multisig_address).expect("Invalid multisig address");
+        let multisig_address =
+            Pubkey::from_str(&multisig_address).expect("Invalid multisig address");
 
         let vault_index = vault_index.unwrap_or(0);
 

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -1,5 +1,6 @@
 use crate::command::config_transaction_create::ConfigTransactionCreate;
 use crate::command::config_transaction_execute::ConfigTransactionExecute;
+use crate::command::display_vault::DisplayVault;
 use crate::command::initiate_program_upgrade::InitiateProgramUpgrade;
 use crate::command::initiate_transfer::InitiateTransfer;
 use crate::command::multisig_create::MultisigCreate;
@@ -8,12 +9,12 @@ use crate::command::proposal_vote::ProposalVote;
 use crate::command::vault_transaction_accounts_close::VaultTransactionAccountsClose;
 use crate::command::vault_transaction_create::VaultTransactionCreate;
 use crate::command::vault_transaction_execute::VaultTransactionExecute;
-use crate::command::display_vault::DisplayVault;
 
 use clap::Subcommand;
 
 pub mod config_transaction_create;
 pub mod config_transaction_execute;
+pub mod display_vault;
 pub mod initiate_program_upgrade;
 pub mod initiate_transfer;
 pub mod multisig_create;
@@ -22,7 +23,6 @@ pub mod proposal_vote;
 pub mod vault_transaction_accounts_close;
 pub mod vault_transaction_create;
 pub mod vault_transaction_execute;
-pub mod display_vault;
 
 #[derive(Subcommand)]
 pub enum Command {

--- a/cli/src/command/vault_transaction_execute.rs
+++ b/cli/src/command/vault_transaction_execute.rs
@@ -87,7 +87,8 @@ impl VaultTransactionExecute {
 
         let rpc_url = rpc_url.unwrap_or_else(|| "https://api.mainnet-beta.solana.com".to_string());
 
-        let transaction_extra_signer_keypair = extra_keypair.map(|path| create_signer_from_path(path).unwrap());
+        let transaction_extra_signer_keypair =
+            extra_keypair.map(|path| create_signer_from_path(path).unwrap());
 
         println!();
         println!(
@@ -185,11 +186,8 @@ impl VaultTransactionExecute {
             signers.push(&**extra_signer);
         }
 
-        let transaction = VersionedTransaction::try_new(
-            VersionedMessage::V0(message),
-            &signers,
-        )
-        .expect("Failed to create transaction");
+        let transaction = VersionedTransaction::try_new(VersionedMessage::V0(message), &signers)
+            .expect("Failed to create transaction");
 
         let signature = send_and_confirm_transaction(&transaction, &rpc_client).await?;
 

--- a/cli/src/command/vault_transaction_execute.rs
+++ b/cli/src/command/vault_transaction_execute.rs
@@ -52,6 +52,9 @@ pub struct VaultTransactionExecute {
 
     #[arg(long)]
     compute_unit_limit: Option<u32>,
+
+    #[arg(long)]
+    extra_keypair: Option<String>,
 }
 
 impl VaultTransactionExecute {
@@ -64,6 +67,7 @@ impl VaultTransactionExecute {
             transaction_index,
             priority_fee_lamports,
             compute_unit_limit,
+            extra_keypair,
         } = self;
 
         let program_id =
@@ -82,6 +86,8 @@ impl VaultTransactionExecute {
         let transaction_pda = get_transaction_pda(&multisig, transaction_index, Some(&program_id));
 
         let rpc_url = rpc_url.unwrap_or_else(|| "https://api.mainnet-beta.solana.com".to_string());
+
+        let transaction_extra_signer_keypair = extra_keypair.map(|path| create_signer_from_path(path).unwrap());
 
         println!();
         println!(
@@ -174,9 +180,14 @@ impl VaultTransactionExecute {
         )
         .unwrap();
 
+        let mut signers = vec![&*transaction_creator_keypair];
+        if let Some(ref extra_signer) = transaction_extra_signer_keypair {
+            signers.push(&**extra_signer);
+        }
+
         let transaction = VersionedTransaction::try_new(
             VersionedMessage::V0(message),
-            &[&*transaction_creator_keypair],
+            &signers,
         )
         .expect("Failed to create transaction");
 


### PR DESCRIPTION
This pull request introduces support for an additional signer keypair in the `VaultTransactionExecute` command, enhancing flexibility for transaction execution. The key changes include adding a new argument for the extra keypair, integrating it into transaction creation, and modifying the signing process.

Enhancements to transaction signing:

* [`cli/src/command/vault_transaction_execute.rs`](diffhunk://#diff-cf036f9931a37bfe66f225820436f9a2b0db8419963f3b570dec724298f94205R55-R57): Added a new argument `extra_keypair` to the `VaultTransactionExecute` struct, allowing users to specify an additional signer keypair.
* [`cli/src/command/vault_transaction_execute.rs`](diffhunk://#diff-cf036f9931a37bfe66f225820436f9a2b0db8419963f3b570dec724298f94205R70): Integrated the `extra_keypair` into the transaction execution logic, including parsing the keypair from the provided path and handling it as an optional signer. [[1]](diffhunk://#diff-cf036f9931a37bfe66f225820436f9a2b0db8419963f3b570dec724298f94205R70) [[2]](diffhunk://#diff-cf036f9931a37bfe66f225820436f9a2b0db8419963f3b570dec724298f94205R90-R91)
* [`cli/src/command/vault_transaction_execute.rs`](diffhunk://#diff-cf036f9931a37bfe66f225820436f9a2b0db8419963f3b570dec724298f94205R183-R190): Updated the transaction creation process to include the additional signer in the `signers` vector when provided.