### PR TITLE
Update action.yaml

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -22,7 +22,7 @@ runs:
         command: |
           curl -sSfL https://release.anza.xyz/v1.18.10/agave-install-init-x86_64-unknown-linux-gnu -o agave-init
           chmod +x agave-init
-          ./agave-init
+          ./agave-init 1.18.10
     - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       shell: bash
     - run: solana-keygen new --no-bip39-passphrase

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -19,7 +19,10 @@ runs:
         max_attempts: 10
         retry_on: error
         shell: bash
-        command: sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.10/agave-install-init-x86_64-unknown-linux-gnu)"
+        command: |
+          curl -sSfL https://release.anza.xyz/v1.18.10/agave-install-init-x86_64-unknown-linux-gnu -o agave-init
+          chmod +x agave-init
+          ./agave-init
     - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       shell: bash
     - run: solana-keygen new --no-bip39-passphrase

--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -19,7 +19,7 @@ runs:
         max_attempts: 10
         retry_on: error
         shell: bash
-        command: sh -c "$(curl -sSfL https://release.solana.com/v${{ env.SOLANA_CLI_VERSION }}/install)"
+        command: sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.10/agave-install-init-x86_64-unknown-linux-gnu)"
     - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       shell: bash
     - run: solana-keygen new --no-bip39-passphrase


### PR DESCRIPTION
This pull request updates the Solana CLI installation command in the GitHub Actions workflow to use a new source URL.

* [`.github/actions/setup-solana/action.yaml`](diffhunk://#diff-d9e1ecff6958f341b4c933b2c287ee498d0f8ca38ffd90458f743008deb2a4d5L22-R22): Changed the `command` under `runs:` to fetch the Solana CLI installation script from `https://release.anza.xyz/v1.18.10/agave-install-init-x86_64-unknown-linux-gnu` instead of `https://release.solana.com/v${{ env.SOLANA_CLI_VERSION }}/install`.