### PR TITLE
chore: update time dep

### DIFF
--- a/sdk/rs/Cargo.toml
+++ b/sdk/rs/Cargo.toml
@@ -18,6 +18,7 @@ futures = { version = "0.3.28" , features = ["async-await", "alloc"] }
 squads-multisig-program = { path = "../../programs/squads_multisig_program", features =["cpi", "no-entrypoint"], version = "2.0.0" }
 solana-client = "1.17.4"
 thiserror = "1.0.48"
+time = ">=0.3.35"
 
 [features]
 default = []

--- a/sdk/rs/Cargo.toml
+++ b/sdk/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squads-multisig"
-version = "2.1.0"
+version = "2.1.1"
 description = "An SDK for building automated programs on Solana"
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- Updates time dep to prevent build errors on rust sdk crate
<img width="1293" height="286" alt="Screenshot 2025-10-01 at 12 08 50 PM" src="https://github.com/user-attachments/assets/ef06d65a-37f7-4f37-9b6f-d6f60b13ff83" />
