### PR TITLE
Security Fix: Spending limit usable by removed multisig members

### DIFF
--- a/programs/squads_multisig_program/src/instructions/spending_limit_use.rs
+++ b/programs/squads_multisig_program/src/instructions/spending_limit_use.rs
@@ -96,10 +96,16 @@ impl SpendingLimitUse<'_> {
             ..
         } = self;
 
-        // member
+        // member - must be in BOTH the spending limit's member list AND the multisig's member list.
+        // SECURITY FIX: Previously only checked spending_limit.members, allowing removed
+        // multisig members to retain spending limit access.
         require!(
             spending_limit.members.contains(&member.key()),
             MultisigError::Unauthorized
+        );
+        require!(
+            multisig.is_member(member.key()).is_some(),
+            MultisigError::NotAMember
         );
 
         // spending_limit - needs no checking.


### PR DESCRIPTION
## Security Finding

### [MEDIUM] Removed Multisig Members Retain Spending Limit Access
**File:** `programs/squads_multisig_program/src/instructions/spending_limit_use.rs:102`

**Issue:**
`spending_limit_use` validates that the caller is in `spending_limit.members` but does NOT verify they are still an active member of the multisig. When a member is removed from the multisig via `config_transaction_execute`, their key remains in any previously-assigned spending limits.

**Attack:**
1. Member A is added to multisig and assigned a spending limit
2. Member A is removed from the multisig (e.g., due to compromise)
3. Member A can still use the spending limit to drain the vault

**Fix:** Added `multisig.is_member(member.key()).is_some()` check to enforce current multisig membership before allowing spending limit use.

---
*Found during a Solana security audit*