### PR TITLE
feat(cli): print tx signature before send for hardware wallet verification

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -23,14 +23,21 @@ pub async fn send_and_confirm_transaction(
     transaction: &VersionedTransaction,
     rpc_client: &RpcClient,
 ) -> eyre::Result<String> {
+    // Print the signature up front so the user can always look the
+    // transaction up, even if confirmation later fails or times out.
+    let signature = transaction
+        .signatures
+        .first()
+        .ok_or_else(|| eyre!("Transaction is missing a signature"))?
+        .to_string();
+
+    println!("Transaction signature: {}", signature.clone().green());
+
     // Try to send and confirm the transaction
     match rpc_client.send_and_confirm_transaction(transaction).await {
-        Ok(signature) => {
-            println!(
-                "Transaction confirmed: {}\n\n",
-                signature.to_string().green()
-            );
-            Ok(signature.to_string())
+        Ok(_) => {
+            println!("{}\n\n", "Transaction confirmed.".green());
+            Ok(signature)
         }
         Err(err) => {
             if let ClientErrorKind::RpcError(RpcError::RpcResponseError {


### PR DESCRIPTION
## Summary
- Print the transaction signature in `send_and_confirm_transaction` **before** the RPC call, so users signing with a Ledger or other hardware wallet can cross-check the hash shown on-device against the one printed by the CLI.
- Previously the signature was only printed after `send_and_confirm` returned `Ok`, which meant (a) it couldn't be verified before signing and (b) it was lost entirely on preflight failure or RPC timeout, leaving no way to look the tx up.
- All CLI commands route their transactions through this single helper, so this one change covers every command (`multisig-create`, `vault-transaction-*`, `config-transaction-*`, `proposal-vote`, `initiate-*`, `claim-rent`, `program-config-init`, …).