### PR TITLE
fix token-2022 transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5137,6 +5137,7 @@ dependencies = [
  "solana-sdk",
  "spl-associated-token-account",
  "spl-token",
+ "spl-token-2022",
  "squads-multisig",
  "tokio",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,4 +26,5 @@ solana-program = "2.2.20"
 clap_v3 = { package = "clap", version = "3.0", optional = false }  # The version needed for solana_clap_utils
 solana-address-lookup-table-interface = "2.2"
 spl-token = "8"
+spl-token-2022 = "8"
 spl-associated-token-account = "7"

--- a/cli/src/command/initiate_batch_transfer.rs
+++ b/cli/src/command/initiate_batch_transfer.rs
@@ -14,7 +14,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::system_instruction;
 use solana_sdk::transaction::VersionedTransaction;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
-use spl_token::instruction::transfer;
+use spl_token_2022::instruction::transfer_checked;
 use squads_multisig::anchor_lang::{AnchorSerialize, InstructionData};
 use squads_multisig::client::get_multisig;
 use squads_multisig::pda::{get_proposal_pda, get_transaction_pda, get_vault_pda};
@@ -248,13 +248,15 @@ impl InitiateBatchTransfer {
                     );
 
                     inner_instructions.push(
-                        transfer(
+                        transfer_checked(
                             &token_program_id,
                             &sender_ata,
+                            &token_mint,
                             &resolved.token_account,
                             &vault_pubkey,
                             &[&vault_pubkey],
                             *amount,
+                            decimals,
                         )
                         .map_err(|e| eyre::eyre!("SPL transfer build failed: {}", e))?,
                     );

--- a/cli/src/command/initiate_transfer.rs
+++ b/cli/src/command/initiate_transfer.rs
@@ -14,7 +14,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::transaction::VersionedTransaction;
 
 use spl_associated_token_account::get_associated_token_address_with_program_id;
-use spl_token::instruction::transfer;
+use spl_token_2022::instruction::transfer_checked;
 use squads_multisig::anchor_lang::{AnchorSerialize, InstructionData};
 use squads_multisig::client::get_multisig;
 use squads_multisig::pda::{get_proposal_pda, get_transaction_pda, get_vault_pda};
@@ -180,13 +180,15 @@ impl InitiateTransfer {
 
         let transfer_message = TransactionMessage::try_compile(
             &vault_pda.0,
-            &[transfer(
+            &[transfer_checked(
                 &token_program_id,
                 &sender_ata,
+                &token_mint,
                 &recipient_ata,
                 &vault_pda.0,
                 &[&vault_pda.0],
                 token_amount_u64,
+                decimals,
             )
             .unwrap()],
             &[],

--- a/cli/src/command/transfer_common.rs
+++ b/cli/src/command/transfer_common.rs
@@ -5,7 +5,17 @@ use solana_sdk::program_pack::Pack;
 use solana_sdk::pubkey::Pubkey;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token::state::{Account as TokenAccount, Mint};
+use spl_token_2022::extension::StateWithExtensions;
+use spl_token_2022::state::Mint as Mint2022;
 use squads_multisig::solana_rpc_client::nonblocking::rpc_client::RpcClient;
+
+fn unpack_mint_decimals(data: &[u8], token_program_id: &Pubkey) -> eyre::Result<u8> {
+    if token_program_id == &spl_token::id() {
+        Ok(Mint::unpack(data)?.decimals)
+    } else {
+        Ok(StateWithExtensions::<Mint2022>::unpack(data)?.base.decimals)
+    }
+}
 
 /// Resolved recipient information for a token transfer.
 pub(crate) struct ResolvedRecipient {
@@ -115,9 +125,9 @@ pub(crate) async fn fetch_mint_decimals(
         ));
     }
 
-    let mint = Mint::unpack(&mint_account.data)
+    let decimals = unpack_mint_decimals(&mint_account.data, token_program_id)
         .map_err(|e| eyre::eyre!("Failed to deserialize mint account {}: {}", token_mint, e))?;
-    Ok(mint.decimals)
+    Ok(decimals)
 }
 
 /// Decimals and SPL token program id inferred from the mint account (mint account owner).
@@ -132,9 +142,9 @@ pub(crate) async fn fetch_mint_decimals_and_token_program(
 
     let token_program_id = mint_account.owner;
 
-    let mint = Mint::unpack(&mint_account.data)
+    let decimals = unpack_mint_decimals(&mint_account.data, &token_program_id)
         .map_err(|e| eyre::eyre!("Failed to deserialize mint account {}: {}", token_mint, e))?;
-    Ok((mint.decimals, token_program_id))
+    Ok((decimals, token_program_id))
 }
 
 pub(crate) fn parse_pubkey(label: &str, s: &str) -> eyre::Result<Pubkey> {


### PR DESCRIPTION
This PR fixes #178's transfers for token-2022. it adds deserializations and `transfer_checked()` capabilities. this was born after I ran the commands which @cavemanloverboy added and it failed when `initiate-batch-transfer` was ran. 