### PR TITLE
fix(cli): accept base58-encoded transaction_message in vault_transaction_create (closes #159)

### DIFF
--- a/cli/src/command/vault_transaction_create.rs
+++ b/cli/src/command/vault_transaction_create.rs
@@ -31,6 +31,14 @@ use squads_multisig::state::Permission;
 
 use crate::utils::{create_signer_from_path, send_and_confirm_transaction};
 
+/// Decode a base58 string into the raw `transaction_message` byte vector
+/// that the on-chain `vault_transaction_create` instruction expects.
+fn parse_base58_transaction_message(s: &str) -> Result<Vec<u8>, String> {
+    solana_sdk::bs58::decode(s)
+        .into_vec()
+        .map_err(|e| format!("invalid base58 in --transaction-message: {e}"))
+}
+
 /// Create a new vault transaction and activate its proposal for voting.
 #[derive(Args)]
 pub struct VaultTransactionCreate {
@@ -57,7 +65,15 @@ pub struct VaultTransactionCreate {
     #[arg(long)]
     vault_index: u8,
 
-    #[arg(long)]
+    /// Base58-encoded `VaultTransactionMessage` bytes. Build the message
+    /// (for example via `transactionMessageBeet` in the TS SDK or by
+    /// serializing `VaultTransactionMessage` server-side), bs58-encode
+    /// the byte vector, and pass it here as a single string.
+    ///
+    /// `Vec<u8>` cannot be used as a direct clap argument: clap parses
+    /// one byte per `--transaction-message` invocation, so a real
+    /// multi-byte message cannot be supplied that way.
+    #[arg(long, value_parser = parse_base58_transaction_message)]
     transaction_message: Vec<u8>,
 
     /// Memo to be included in the transaction


### PR DESCRIPTION
## Summary

Closes #159.

`--transaction-message` on `squads-multisig-cli vault-transaction-create` is typed as `Vec<u8>`, which clap parses as **one byte per `--transaction-message` invocation**. A real `VaultTransactionMessage` is many bytes long, so as-written there is no way to actually pass one through this argument — the CLI accepts the flag but cannot accept a real message (which is what #159 reports).

## Fix

Take the message as a single base58-encoded string and decode it inside a `clap::value_parser`. The decoded `Vec<u8>` flows through the rest of the function unchanged — the on-chain instruction continues to receive the same bytes.

```rust
fn parse_base58_transaction_message(s: &str) -> Result<Vec<u8>, String> {
    solana_sdk::bs58::decode(s)
        .into_vec()
        .map_err(|e| format!(\"invalid base58 in --transaction-message: {e}\"))
}

#[arg(long, value_parser = parse_base58_transaction_message)]
transaction_message: Vec<u8>,
```

Base58 matches the rest of the Squads CLI (`multisig_pubkey` is already base58 parsed via `Pubkey::from_str`) and `bs58` is already available via `solana_sdk` so no new dependency is added.

## Usage after fix

```
squads-multisig-cli vault-transaction-create \
  --keypair ./keypair.json \
  --multisig-pubkey 6Mz4...Asdf \
  --vault-index 0 \
  --transaction-message <base58-encoded-VaultTransactionMessage>
```

## Test plan

- [x] Diff compiles with the existing `solana-sdk` dependency (no new crate added).
- [ ] CI: please run the cli build/test suite — happy to follow up if maintainers want a small unit test for the parser fn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)