### PR TITLE
fix(cli): resolve SpendingLimit details on RemoveSpendingLimit display (MUL-754 / V4-19)

### DIFF
--- a/cli/src/command/display_config_transaction.rs
+++ b/cli/src/command/display_config_transaction.rs
@@ -2,6 +2,7 @@ use clap::Args;
 use colored::Colorize;
 use solana_sdk::pubkey::Pubkey;
 use squads_multisig::anchor_lang::AccountDeserialize;
+use squads_multisig::client::get_spending_limit;
 use squads_multisig::solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use squads_multisig::squads_multisig_program::state::ConfigTransaction;
 use squads_multisig::state::{ConfigAction, Period, Permission, Permissions};
@@ -152,6 +153,43 @@ impl DisplayConfigTransaction {
                         format!("Action {}: Remove Spending Limit", i + 1).yellow().bold()
                     );
                     println!("  Spending Limit: {}", spending_limit);
+                    // Resolve the referenced SpendingLimit account so reviewers can see
+                    // exactly which delegated spend authority is being revoked, rather than
+                    // an opaque PDA. If the lookup fails, warn explicitly instead of treating
+                    // the bare PDA as adequate review material.
+                    match get_spending_limit(&rpc_client, spending_limit).await {
+                        Ok(limit) => {
+                            println!("  Vault Index:  {}", limit.vault_index);
+                            println!("  Mint:         {}", limit.mint);
+                            println!("  Amount:       {}", limit.amount);
+                            println!("  Period:       {}", format_period(limit.period));
+                            if limit.members.is_empty() {
+                                println!("  Members:      (all)");
+                            } else {
+                                println!("  Members:");
+                                for m in &limit.members {
+                                    println!("    {}", m);
+                                }
+                            }
+                            if limit.destinations.is_empty() {
+                                println!("  Destinations: (any)");
+                            } else {
+                                println!("  Destinations:");
+                                for d in &limit.destinations {
+                                    println!("    {}", d);
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            println!(
+                                "{}",
+                                "  WARNING: could not resolve the referenced spending limit \
+                                 account; the details of the guardrail being removed cannot be \
+                                 verified from this output."
+                                    .red()
+                            );
+                        }
+                    }
                 }
                 ConfigAction::SetRentCollector { new_rent_collector } => {
                     println!(


### PR DESCRIPTION
## Summary
Resolves Cantina finding **V4-19** (Linear **MUL-754**).

`display-config-transaction` rendered `RemoveSpendingLimit` as only an opaque PDA, so reviewers could not see which delegated spend authority was being revoked and could approve the wrong removal while a broader limit stayed live.

## Change
- Resolve the referenced `SpendingLimit` account (via the existing `get_spending_limit` SDK helper) and print its vault index, mint, amount, period, members, and destinations.
- Print an explicit warning when the lookup/deserialization fails, instead of treating the bare PDA as adequate review material.

Scope: `cli/src/command/display_config_transaction.rs` only. Builds clean (`cargo build -p squads-multisig-cli`).

Closes MUL-754

🤖 Generated with [Claude Code](https://claude.com/claude-code)