### PR TITLE
fix(cli): correct rent-collector example and warn on config-authority misuse (MUL-757 / V4-10)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -183,7 +183,7 @@ multisig-create --rpc-url <RPC_URL> --program-id <PROGRAM_ID> --keypair <KEYPAIR
 - `--rpc-url <RPC_URL>`: (Optional) The URL of the Solana RPC endpoint. Defaults to mainnet if not specified.
 - `--program-id <PROGRAM_ID>`: (Optional) The ID of the multisig program. Defaults to a standard ID if not specified.
 - `--keypair <KEYPAIR_PATH>`: Path to your keypair file.
-- `--config-authority <CONFIG_AUTHORITY>`: (Optional) Address of the Program Config Authority.
+- `--config-authority <CONFIG_AUTHORITY>`: (Optional) Address granted **unilateral** control over the multisig configuration (add/remove members, change threshold, etc.). This makes the multisig "controlled" rather than autonomous — only set it if you intend a single key to govern config changes. This is **not** the rent collector; use `--rent-collector` for that.
 - `--members <MEMBER_...>`: List of members' public keys, separated by spaces.
 - `--threshold <THRESHOLD>`: The threshold number of signatures required for executing multisig transactions.
 - `--rent-collector <RENT_COLLECTOR>` : The Public key that will be able to reclaim rent from canceled and executed transactions.
@@ -208,7 +208,7 @@ multisig-create --rpc-url <RPC_URL> --program-id <PROGRAM_ID> --keypair <KEYPAIR
 
 3. **Creating a Multisig with Rent Collector:**
    ```bash
-   multisig-create --keypair /path/to/keypair.json --config-authority <RENT_COLLECTOR_PUBKEY> --members "Member1PubKey,Permission1" "Member2PubKey,Permission2" --threshold 1
+   multisig-create --keypair /path/to/keypair.json --rent-collector <RENT_COLLECTOR_PUBKEY> --members "Member1PubKey,Permission1" "Member2PubKey,Permission2" --threshold 1
    ```
    Initializes a multisig account with a specified rent collector and a threshold of 1.
 

--- a/cli/src/command/multisig_create.rs
+++ b/cli/src/command/multisig_create.rs
@@ -45,7 +45,10 @@ pub struct MultisigCreate {
     #[arg(long)]
     fee_payer_keypair: Option<String>,
 
-    /// Address of the Program Config Authority that will be set to control the Program Config
+    /// Address granted UNILATERAL control over the multisig configuration
+    /// (add/remove members, change threshold, etc.). Setting this makes the
+    /// multisig "controlled" rather than autonomous. This is NOT the rent
+    /// collector — use --rent-collector for that.
     #[arg(long)]
     config_authority: Option<String>,
 
@@ -123,6 +126,21 @@ impl MultisigCreate {
         );
         println!("Members amount:      {}", members.len());
         println!();
+
+        // A config authority grants unilateral governance over the multisig. If it is set
+        // while the rent collector is unset, the operator may have confused the two flags
+        // (e.g. passed a rent-collector key to --config-authority), so warn explicitly.
+        if config_authority.is_some() && rent_collector.is_none() {
+            println!(
+                "{}",
+                "⚠️  WARNING: --config-authority is set but --rent-collector is not. The \
+                 config authority has UNILATERAL control over this multisig's configuration \
+                 (members, threshold, etc.). If you meant to set a rent collector, re-run \
+                 with --rent-collector instead."
+                    .red()
+            );
+            println!();
+        }
 
         let config_authority = config_authority.map(|s| Pubkey::from_str(&s)).transpose()?;
 


### PR DESCRIPTION
## Summary
Resolves Cantina finding **V4-10** (Linear **MUL-757**).

The README `multisig-create` rent-collector example used `--config-authority <RENT_COLLECTOR_PUBKEY>`. Copying it assigns the supplied key to `config_authority` (the unilateral governance signer for multisig configuration) and leaves `rent_collector` unset.

## Change
- Fix the README example to use `--rent-collector`.
- Clarify in both the README and the CLI `--config-authority` help text that it grants **unilateral** control over multisig configuration and is **not** the rent collector.
- Emit a warning at creation time when `--config-authority` is set while `--rent-collector` is unset (the likely confusion case).

Note: the finding's checklist also suggested a docs/CLI argument-parity test; not included here (heavier test scaffolding) — happy to add as a follow-up.

Scope: `cli/README.md`, `cli/src/command/multisig_create.rs`. Builds clean.

Closes MUL-757

🤖 Generated with [Claude Code](https://claude.com/claude-code)