### PR TITLE
fix(cli): display proposals extra data

### DIFF
--- a/cli/src/command/display_proposals.rs
+++ b/cli/src/command/display_proposals.rs
@@ -6,9 +6,27 @@ use solana_sdk::clock::Clock;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::sysvar;
 use squads_multisig::anchor_lang::AccountDeserialize;
-use squads_multisig::pda::get_proposal_pda;
+use squads_multisig::pda::{get_proposal_pda, get_transaction_pda};
 use squads_multisig::solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use squads_multisig::squads_multisig_program::state::{Batch, ConfigTransaction, VaultTransaction};
 use squads_multisig::state::{Multisig, Proposal, ProposalStatus};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TxKind {
+    Vault,
+    Config,
+    Batch,
+}
+
+impl TxKind {
+    fn label(self) -> &'static str {
+        match self {
+            TxKind::Vault => "Vault Transaction",
+            TxKind::Config => "Config Transaction",
+            TxKind::Batch => "Batch",
+        }
+    }
+}
 
 /// Fetch and display all proposals for a multisig, showing their status and transaction index.
 #[derive(Args)]
@@ -98,35 +116,49 @@ impl DisplayProposals {
         // Iterate through recent transaction indices in reverse order (most recent first)
         for idx in (start_idx..=transaction_index).rev() {
             let proposal_pda = get_proposal_pda(&multisig, idx, Some(&program_id));
+            let transaction_pda = get_transaction_pda(&multisig, idx, Some(&program_id));
 
-            // Try to fetch the proposal account
-            match rpc_client.get_account(&proposal_pda.0).await {
-                Ok(account) => {
-                    // Deserialize the proposal
-                    match Proposal::try_deserialize(&mut account.data.as_slice()) {
-                        Ok(proposal) => {
-                            // Check if proposal is outstanding (Draft, Active, or Approved)
-                            let is_outstanding = matches!(
-                                proposal.status,
-                                ProposalStatus::Draft { .. }
-                                    | ProposalStatus::Active { .. }
-                                    | ProposalStatus::Approved { .. }
-                            );
+            // Fetch the proposal and its linked transaction account together
+            let accounts = match rpc_client
+                .get_multiple_accounts(&[proposal_pda.0, transaction_pda.0])
+                .await
+            {
+                Ok(accounts) => accounts,
+                Err(_) => continue,
+            };
 
-                            if is_outstanding {
-                                outstanding_proposals.push((idx, proposal));
-                            }
-                        }
-                        Err(_) => {
-                            // Account exists but failed to deserialize - skip
-                            continue;
-                        }
-                    }
+            let proposal = match accounts[0].as_ref() {
+                Some(account) => match Proposal::try_deserialize(&mut account.data.as_slice()) {
+                    Ok(proposal) => proposal,
+                    // Account exists but failed to deserialize - skip
+                    Err(_) => continue,
+                },
+                // Account doesn't exist - skip
+                None => continue,
+            };
+
+            let kind = accounts[1].as_ref().and_then(|tx_acc| {
+                if Batch::try_deserialize(&mut tx_acc.data.as_slice()).is_ok() {
+                    Some(TxKind::Batch)
+                } else if VaultTransaction::try_deserialize(&mut tx_acc.data.as_slice()).is_ok() {
+                    Some(TxKind::Vault)
+                } else if ConfigTransaction::try_deserialize(&mut tx_acc.data.as_slice()).is_ok() {
+                    Some(TxKind::Config)
+                } else {
+                    None
                 }
-                Err(_) => {
-                    // Account doesn't exist - skip
-                    continue;
-                }
+            });
+
+            // Check if proposal is outstanding (Draft, Active, or Approved)
+            let is_outstanding = matches!(
+                proposal.status,
+                ProposalStatus::Draft { .. }
+                    | ProposalStatus::Active { .. }
+                    | ProposalStatus::Approved { .. }
+            );
+
+            if is_outstanding {
+                outstanding_proposals.push((idx, proposal, kind));
             }
         }
 
@@ -146,40 +178,74 @@ impl DisplayProposals {
         println!();
 
         // Display proposals
-        for (idx, proposal) in outstanding_proposals {
+        for (idx, proposal, kind) in outstanding_proposals {
             println!("{}", "─".repeat(80).bright_black());
             println!("Transaction Index: {}", idx.to_string().cyan());
             println!(
                 "Proposal PDA:     {}",
                 get_proposal_pda(&multisig, idx, Some(&program_id)).0
             );
+            println!(
+                "Type:             {}",
+                kind.map(TxKind::label).unwrap_or("Unknown")
+            );
+
+            // Proposals at or below the stale index can no longer be activated or voted
+            // on; approved config transactions can no longer be executed. Approved
+            // vault/batch transactions remain executable even when stale.
+            let is_stale = idx <= multisig_account.stale_transaction_index;
 
             // Display status
             let status_str = match &proposal.status {
                 ProposalStatus::Draft { timestamp } => {
-                    format!(
+                    let base = format!(
                         "Draft (created: {})",
                         format_timestamp(*timestamp, current_timestamp)
-                    )
+                    );
+                    if is_stale {
+                        format!("{} — stale, can no longer be activated", base).red()
+                    } else {
+                        base.yellow()
+                    }
                 }
                 ProposalStatus::Active { timestamp } => {
-                    format!(
+                    let base = format!(
                         "Active (activated: {})",
                         format_timestamp(*timestamp, current_timestamp)
-                    )
+                    );
+                    if is_stale {
+                        format!("{} — stale, can no longer be voted on", base).red()
+                    } else {
+                        base.yellow()
+                    }
                 }
                 ProposalStatus::Approved { timestamp } => {
-                    format!(
+                    let base = format!(
                         "Approved (approved: {})",
                         format_timestamp(*timestamp, current_timestamp)
-                    )
+                    );
+                    if is_stale && kind == Some(TxKind::Config) {
+                        format!("{} — stale, can no longer be executed", base).red()
+                    } else {
+                        let unlock_at = timestamp + i64::from(multisig_account.time_lock);
+                        if current_timestamp >= unlock_at {
+                            format!("{} — executable now", base).green()
+                        } else {
+                            format!(
+                                "{} — timelocked, unlocks in {}",
+                                base,
+                                format_duration(unlock_at - current_timestamp)
+                            )
+                            .yellow()
+                        }
+                    }
                 }
                 // Filtered out by is_outstanding check above
                 _ => unreachable!(
                     "We filtered proposals by status above, so this should never happen"
                 ),
             };
-            println!("Status:           {}", status_str.yellow());
+            println!("Status:           {}", status_str);
 
             // Display votes
             println!("Approved by:     {} member(s)", proposal.approved.len());
@@ -225,5 +291,17 @@ fn format_timestamp(timestamp: i64, current_timestamp: i64) -> String {
         format!("{} hours ago", diff / 3600)
     } else {
         format!("{} days ago", diff / 86400)
+    }
+}
+
+fn format_duration(seconds: i64) -> String {
+    if seconds < 60 {
+        format!("{} seconds", seconds)
+    } else if seconds < 3600 {
+        format!("{} minutes", seconds / 60)
+    } else if seconds < 86400 {
+        format!("{} hours", seconds / 3600)
+    } else {
+        format!("{} days", seconds / 86400)
     }
 }


### PR DESCRIPTION
This pull request enhances the `display_proposals` CLI command by improving how proposals and their linked transactions are fetched, classified, and displayed. It introduces transaction type detection, enables richer status reporting (including handling of stale and timelocked proposals), and adds a utility for formatting time durations.

**Proposal and Transaction Fetching & Classification**
- Fetches both the proposal and its associated transaction account in a single RPC call, improving efficiency and reliability. The transaction account is then classified as a Vault, Config, or Batch transaction using a new `TxKind` enum. [[1]](diffhunk://#diff-da4596df3df941cc7fefe29eb83c5e86a06ca061f27aff4e1eb9d1ef446396bdL9-R30) [[2]](diffhunk://#diff-da4596df3df941cc7fefe29eb83c5e86a06ca061f27aff4e1eb9d1ef446396bdR119-L107)

**Display Improvements**
- Displays the transaction type for each proposal and provides more informative status messages, including whether a proposal is stale, executable, or timelocked. The status color-coding is enhanced for better clarity.

**Utility Functions**
- Adds a new `format_duration` function to present time until unlock in a human-friendly way.