### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ mod command;
 pub mod utils;
 
 #[derive(Parser)]
+#[command(version)]
 struct App {
     #[command(subcommand)]
     command: Command,


### PR DESCRIPTION
Adds `#[command(version)]` to the top-level parser so the CLI reports its version:

    $ squads-multisig-cli --version
    squads-multisig-cli 0.1.8

The version is read from `CARGO_PKG_VERSION`, so it stays in sync with `cli/Cargo.toml` automatically.
