### PR TITLE
chore(docs): updated comments and security around membership state/consensus

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,7 +56,7 @@ $25,000 USD in locked SOL tokens (locked for 12 months):
 $10,000 USD in locked SOL tokens (locked for 12 months): 
 * Modification of any Multisig or module settings without proper authorization by the owners of the Multisig
 ### In Scope
-Squads V3 on-chain program () is in scope for the bounty program.
+Squads V4 on-chain program (`SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf`) is in scope for the bounty program.
 ### Out of Scope
 The following components are out of scope for the bounty program: 
 * any encrypted credentials, auth tokens, etc. checked into the repo 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,3 +86,14 @@ We ask that:
 * You do not exploit a security issue you discover for any reason. This includes demonstrating additional risk, such as an attempted compromise of sensitive company data or probing for additional issues. 
 * You have not violated any other applicable laws or regulations. 
 * You are not currently subject to any U.S. sanctions administered by the Office of Foreign Assets Control of the U.S. Department of the Treasury (“OFAC”).
+## Protocol Design Invariants
+
+The following behaviors are intentional properties of the Squads Protocol governance model and, by themselves, do not constitute security vulnerabilities:
+
+* **Governance finality.** Once a proposal or transaction has reached consensus (e.g. `Approved` or `ExecuteReady`), subsequent multisig configuration changes are not intended to retroactively invalidate, recalculate, or otherwise alter that proposal or transaction. Configuration changes are prospective, not retroactive.
+
+* **Staleness and deprecation.** Staleness (`stale_transaction_index`) and deprecation (`ms_change_index`) mechanisms are designed to invalidate proposals and transactions that have **not yet reached consensus**. They are not intended to revoke or invalidate governance decisions that have already achieved the required approvals.
+
+* **Independent authorization models.** Certain protocol features intentionally maintain authorization state independent of multisig membership. For example, Spending Limit delegates are managed separately from multisig members, and changes to multisig membership do not implicitly grant or revoke Spending Limit permissions. Such permissions must be managed through their respective administrative mechanisms.
+
+Reports describing the above behaviors as vulnerabilities, without demonstrating an unintended violation of these design invariants, will generally be considered expected protocol behavior rather than security issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -90,7 +90,7 @@ We ask that:
 
 The following behaviors are intentional properties of the Squads Protocol governance model and, by themselves, do not constitute security vulnerabilities:
 
-* **Governance finality.** Once a proposal or transaction has reached consensus (e.g. `Approved` or `ExecuteReady`), subsequent multisig configuration changes are not intended to retroactively invalidate, recalculate, or otherwise alter that proposal or transaction. Configuration changes are prospective, not retroactive.
+* **Governance finality.** Once a proposal or transaction has reached consensus (e.g. `Approved` or `ExecuteReady`), subsequent multisig *configuration changes* are not intended to retroactively invalidate, recalculate, or otherwise alter that proposal or transaction. Configuration changes are prospective, not retroactive. This does not preclude an `Approved` proposal from being cancelled: cancellation is itself a first-class governance action that requires a fresh threshold of cancellation votes from current members before the proposal transitions to `Cancelled`. Altering a reached-consensus decision therefore requires the same consensus process that produced it — it cannot be achieved as a side effect of a configuration change.
 
 * **Staleness and deprecation.** Staleness (`stale_transaction_index`) and deprecation (`ms_change_index`) mechanisms are designed to invalidate proposals and transactions that have **not yet reached consensus**. They are not intended to revoke or invalidate governance decisions that have already achieved the required approvals.
 

--- a/programs/squads_multisig_program/src/instructions/multisig_add_spending_limit.rs
+++ b/programs/squads_multisig_program/src/instructions/multisig_add_spending_limit.rs
@@ -19,7 +19,8 @@ pub struct MultisigAddSpendingLimitArgs {
     /// When it passes, the remaining amount is reset, unless it's `Period::OneTime`.
     pub period: Period,
     /// Members of the Spending Limit that can use it.
-    /// Don't have to be members of the multisig.
+    /// These can be any pubkey capable of signing and are NOT tied to multisig
+    /// membership; this list is managed independently of the multisig's members.
     pub members: Vec<Pubkey>,
     /// The destination addresses the spending limit is allowed to sent funds to.
     /// If empty, funds can be sent to any address.

--- a/programs/squads_multisig_program/src/instructions/multisig_config.rs
+++ b/programs/squads_multisig_program/src/instructions/multisig_config.rs
@@ -121,6 +121,9 @@ impl MultisigConfig<'_> {
     ///
     /// NOTE: This instruction must be called only by the `config_authority` if one is set (Controlled Multisig).
     ///       Uncontrolled Mustisigs should use `config_transaction_create` instead.
+    /// NOTE: Removing a member from the multisig does NOT revoke any Spending Limit access.
+    ///       Spending Limit membership is tracked independently (see `SpendingLimit::members`);
+    ///       to revoke a member's Spending Limit access, update the relevant Spending Limit(s).
     #[access_control(ctx.accounts.validate())]
     pub fn multisig_remove_member(
         ctx: Context<Self>,

--- a/programs/squads_multisig_program/src/state/config_transaction.rs
+++ b/programs/squads_multisig_program/src/state/config_transaction.rs
@@ -64,9 +64,13 @@ pub enum ConfigAction {
         /// The reset period of the spending limit.
         /// When it passes, the remaining amount is reset, unless it's `Period::OneTime`.
         period: Period,
-        /// Members of the multisig that can use the spending limit.
-        /// In case a member is removed from the multisig, the spending limit will remain existent
-        /// (until explicitly deleted), but the removed member will not be able to use it anymore.
+        /// Members that can use the spending limit.
+        /// These can be any pubkey capable of signing and are NOT tied to multisig
+        /// membership. Spending limit membership is tracked independently: adding or
+        /// removing a multisig member does NOT add or remove them from any spending
+        /// limit, and a member removed from the multisig who is still listed here can
+        /// continue to use the spending limit. To change who can use a spending limit,
+        /// remove and re-add the spending limit with the desired members.
         members: Vec<Pubkey>,
         /// The destination addresses the spending limit is allowed to sent funds to.
         /// If empty, funds can be sent to any address.

--- a/programs/squads_multisig_program/src/state/spending_limit.rs
+++ b/programs/squads_multisig_program/src/state/spending_limit.rs
@@ -38,8 +38,11 @@ pub struct SpendingLimit {
     pub bump: u8,
 
     /// Members of the spending limit that can use it.
-    /// Don't have to be members of the multisig.
-    /// To remove members from the spending limit: Close and re-initialize 
+    /// These can be any pubkey capable of signing and are NOT tied to multisig
+    /// membership. This list is tracked independently of the multisig's member list:
+    /// adding or removing a multisig member does NOT modify it, and a member removed
+    /// from the multisig who is still listed here can continue to use the spending limit.
+    /// To change who can use the spending limit: close and re-initialize it.
     pub members: Vec<Pubkey>,
 
     /// The destination addresses the spending limit is allowed to sent funds to.


### PR DESCRIPTION
This pull request clarifies and documents the independent authorization model for Spending Limits in the Squads Protocol. It emphasizes that Spending Limit permissions are managed separately from multisig membership, and changes to one do not automatically affect the other. The documentation is updated throughout the codebase and the security policy to make this distinction explicit.

**Documentation and Protocol Invariants:**

* Added a new section "Protocol Design Invariants" to `SECURITY.md`, specifying that independent authorization for Spending Limits is an intentional property of the protocol, and clarifying that such behaviors are not security vulnerabilities.

**Spending Limit Membership Independence:**

* Updated comments in `SpendingLimit`, `MultisigAddSpendingLimitArgs`, and `ConfigAction` to clarify that Spending Limit members are managed independently of multisig members, and changes to multisig membership do not implicitly grant or revoke Spending Limit access. [[1]](diffhunk://#diff-d1f81c514307c644c3b4f5668d931090776a6214c95a44c0164028e1894d4949L41-R45) [[2]](diffhunk://#diff-a9e818f4965ad6ff83bd0ed601ff503485d3a5c400cc8f5490b1a04dee72eec1L22-R23) [[3]](diffhunk://#diff-eb7cf070be740418a9d50132212d8aede4d64662f47394c2a2cfd0b40d82bfc4L67-R73)
* Enhanced documentation for `multisig_remove_member` in `MultisigConfig` to state that removing a multisig member does not revoke their Spending Limit access, which must be managed separately.