### PR TITLE
build: add cached docker program build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+node_modules
+target
+.superpowers
+docs
+sdk/multisig/docs
+audits

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,40 @@
+name: Docker Build
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile.build'
+      - '.dockerignore'
+      - 'Makefile'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain'
+      - 'programs/**'
+      - 'sdk/rs/**'
+      - 'cli/**'
+      - '.github/workflows/docker-build.yaml'
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build program
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Gives `docker build` the buildx driver, which is what makes the GitHub Actions
+      # cache backend available to the cache mounts in Dockerfile.build.
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        run: make build DOCKER_BUILD_FLAGS='--cache-from type=gha --cache-to type=gha,mode=max'
+
+      # The build succeeding is not enough on its own: --output writes whatever the
+      # artifacts stage contains, so an empty or missing .so would still exit 0.
+      - name: Report the artifact
+        run: |
+          test -s target/deploy/squads_multisig_program.so
+          ls -l target/deploy/squads_multisig_program.so
+          sha256sum target/deploy/squads_multisig_program.so

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM solanafoundation/solana-verifiable-build:2.3.13 AS builder
+
+WORKDIR /build
+
+# The image already carries platform-tools and cargo-build-sbf. It does not carry the
+# host toolchain this repo pins in rust-toolchain, which rustup syncs on first use.
+# Installing it in its own layer keeps that download out of every source-change rebuild.
+COPY rust-toolchain ./
+RUN rustup toolchain install "$(cat rust-toolchain)"
+
+# The program is a workspace member, so cargo needs the workspace manifest, the
+# lockfile, and every member present to resolve the dependency graph. LICENSE is here
+# because the program manifest points at it with license-file.
+COPY Cargo.toml Cargo.lock LICENSE ./
+COPY programs ./programs
+COPY sdk/rs ./sdk/rs
+COPY cli ./cli
+
+# /build/target is a cache mount, so nothing under it survives into an image layer.
+# The artifact has to be copied out inside this same RUN.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    set -e; \
+    mkdir -p /artifacts; \
+    cargo build-sbf --manifest-path programs/squads_multisig_program/Cargo.toml -- --locked; \
+    cp target/deploy/squads_multisig_program.so /artifacts/
+
+FROM scratch AS artifacts
+COPY --from=builder /artifacts/squads_multisig_program.so /

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# CI passes the GitHub Actions cache backend through this. Empty locally, where the
+# daemon's own cache already persists between builds.
+DOCKER_BUILD_FLAGS ?=
+
+.PHONY: build clean-docker
+
+# The program builds inside Docker so no Solana or Anchor toolchain is needed on the
+# host. --output writes the .so as the invoking user, so nothing in target/ ends up
+# root-owned. The container's target/ is a BuildKit cache mount, which also keeps it
+# from sharing a fingerprint directory with any host cargo build.
+build:
+	DOCKER_BUILDKIT=1 docker build --platform linux/amd64 $(DOCKER_BUILD_FLAGS) \
+		-f Dockerfile.build --target artifacts \
+		--output type=local,dest=target/deploy .
+
+# BuildKit has no project-level filter for cache mounts, so this scopes to ours by
+# matching the program name that appears in the RUN command each mount is recorded
+# against. A different Dockerfile whose build command also contains that text would
+# match too, but that is the narrowest filter BuildKit's cache mount type supports.
+clean-docker:
+	docker builder prune -f --filter type=exec.cachemount --filter 'description~=squads_multisig'

--- a/README.md
+++ b/README.md
@@ -53,37 +53,22 @@ Documentation:
 
 ## Compiling and testing
 
-You can compile the code with Anchor. If you do not have the Solana Anchor framework CLI installed, you can do so by following [this guide](https://www.anchor-lang.com/docs/installation).
+The program builds inside Docker, so no Solana toolchain, Anchor CLI, or `avm` is
+needed on the host. Only Docker itself is required.
 
 ```
-agave-install init 1.18.16
-avm use 0.29.0
-anchor clean # if you want to refresh your build
-anchor build
+make build
 ```
 
-You may encounter two issues compiling:
+That writes `target/deploy/squads_multisig_program.so`. The build runs in
+`solanafoundation/solana-verifiable-build:2.3.13`, which is an amd64-only image, so on
+an arm64 host it runs emulated and the first build is slow. The cargo registry, the
+cargo git checkouts, and the SBF `target/` directory are BuildKit cache mounts, so
+later builds reuse them and recompile only what changed.
 
-### 1. Problem installing edition2024
-
-This was stabilized in rustc version 1.85.0. You can override your rust version with the following command:
-
-```
-rustup override set 1.85.0
-```
-This will override the rust toolchain you are currently using to 1.85.0. You can then run `anchor build` as normal
-
-### 2. Cargo.lock version 4
-
-After running `cargo build`, you might get an error indicating that the new lockfile version requires a new flag. Instead, manually edit your Cargo.lock file to set it to version 3:
-
-```
-# Cargo.lock
-...
-version = 3
-```
-
-You can then run `anchor build` as normal.
+`make clean-docker` prunes those caches. BuildKit offers no project-level filter for
+cache mounts, so it matches on the program name and could in principle match another
+project whose build command contains the same text.
 
 To deploy the program on a local validator instance for testing or development purposes, you can create a local instance by running this command from the [Solana CLI](https://docs.solana.com/cli/install-solana-cli-tools).
 


### PR DESCRIPTION
## Summary
- Build the program in Docker via `make build`, removing the need for a Solana toolchain, Anchor CLI, or `avm` on the host
- Add a `Docker Build` workflow that runs the same `make build` on every pull request touching the build inputs, and asserts the resulting `.so` is non-empty
- Replace the README build instructions, which pinned `agave-install 1.18.16` and `avm use 0.29.0` against a tree that needs Anchor 0.32 and Solana 2.2

## Testing
- `make build` from a clean checkout, producing `target/deploy/squads_multisig_program.so` at 867640 bytes
- A second `make build` with no source changes, fully served from cache